### PR TITLE
Optimize Symfony

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bad60cd4a061879daf8059d2c675e785",
+    "hash": "17e44af7558c936fd64ccb5573fad7e8",
+    "content-hash": "b5369c9830306d8a60a171e91a6e591e",
     "packages": [
         {
             "name": "aura/di",
@@ -56,7 +57,7 @@
                 "di",
                 "di container"
             ],
-            "time": "2016-10-04T15:52:29+00:00"
+            "time": "2016-10-04 15:52:29"
         },
         {
             "name": "bitexpert/disco",
@@ -106,7 +107,7 @@
                 }
             ],
             "description": "Dependency Injection Container",
-            "time": "2017-01-07T08:35:38+00:00"
+            "time": "2017-01-07 08:35:38"
         },
         {
             "name": "bitexpert/slf4psrlog",
@@ -152,7 +153,7 @@
                 }
             ],
             "description": "Simple Logging Facade for Loggers implementing PSR-3 logging interface.",
-            "time": "2015-10-18T15:43:07+00:00"
+            "time": "2015-10-18 15:43:07"
         },
         {
             "name": "container-interop/container-interop",
@@ -179,7 +180,7 @@
                 "MIT"
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "time": "2014-12-30T15:22:37+00:00"
+            "time": "2014-12-30 15:22:37"
         },
         {
             "name": "doctrine/annotations",
@@ -247,7 +248,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2016-12-30T15:59:45+00:00"
+            "time": "2016-12-30 15:59:45"
         },
         {
             "name": "doctrine/cache",
@@ -317,7 +318,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-10-29T11:16:17+00:00"
+            "time": "2016-10-29 11:16:17"
         },
         {
             "name": "doctrine/lexer",
@@ -371,7 +372,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09T13:34:57+00:00"
+            "time": "2014-09-09 13:34:57"
         },
         {
             "name": "illuminate/container",
@@ -547,7 +548,7 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2016-12-30T09:49:15+00:00"
+            "time": "2016-12-30 09:49:15"
         },
         {
             "name": "ocramius/proxy-manager",
@@ -612,7 +613,7 @@
                 "proxy pattern",
                 "service proxies"
             ],
-            "time": "2016-11-04T15:53:15+00:00"
+            "time": "2016-11-04 15:53:15"
         },
         {
             "name": "php-di/invoker",
@@ -655,7 +656,7 @@
                 "invoke",
                 "invoker"
             ],
-            "time": "2016-07-14T13:09:58+00:00"
+            "time": "2016-07-14 13:09:58"
         },
         {
             "name": "php-di/php-di",
@@ -715,7 +716,7 @@
                 "dependency injection",
                 "di"
             ],
-            "time": "2016-08-23T20:18:00+00:00"
+            "time": "2016-08-23 20:18:00"
         },
         {
             "name": "php-di/phpdoc-reader",
@@ -752,7 +753,7 @@
                 "phpdoc",
                 "reflection"
             ],
-            "time": "2015-11-29T10:34:25+00:00"
+            "time": "2015-11-29 10:34:25"
         },
         {
             "name": "phpixie/di",
@@ -800,7 +801,7 @@
                 "dependency injection",
                 "di"
             ],
-            "time": "2016-05-25T09:21:03+00:00"
+            "time": "2016-05-25 09:21:03"
         },
         {
             "name": "pimple/pimple",
@@ -846,7 +847,7 @@
                 "container",
                 "dependency injection"
             ],
-            "time": "2015-09-11T15:10:35+00:00"
+            "time": "2015-09-11 15:10:35"
         },
         {
             "name": "psr/log",
@@ -893,7 +894,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2016-10-10 12:19:37"
         },
         {
             "name": "rdlowrey/auryn",
@@ -954,7 +955,7 @@
                 "dic",
                 "ioc"
             ],
-            "time": "2016-03-14T20:10:19+00:00"
+            "time": "2016-03-14 20:10:19"
         },
         {
             "name": "symfony/config",
@@ -1010,7 +1011,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-09T07:45:17+00:00"
+            "time": "2016-12-09 07:45:17"
         },
         {
             "name": "symfony/dependency-injection",
@@ -1073,7 +1074,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2016-12-08T15:27:33+00:00"
+            "time": "2016-12-08 15:27:33"
         },
         {
             "name": "symfony/filesystem",
@@ -1122,7 +1123,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-11-24T00:46:43+00:00"
+            "time": "2016-11-24 00:46:43"
         },
         {
             "name": "woohoolabs/zen",
@@ -1179,7 +1180,7 @@
                 "di",
                 "dic"
             ],
-            "time": "2017-01-05T13:04:12+00:00"
+            "time": "2017-01-05 13:04:12"
         },
         {
             "name": "zendframework/zend-code",
@@ -1232,7 +1233,7 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-10-24T13:23:32+00:00"
+            "time": "2016-10-24 13:23:32"
         },
         {
             "name": "zendframework/zend-eventmanager",
@@ -1286,7 +1287,7 @@
                 "events",
                 "zf2"
             ],
-            "time": "2016-12-19T21:47:12+00:00"
+            "time": "2016-12-19 21:47:12"
         },
         {
             "name": "zendframework/zend-servicemanager",
@@ -1347,7 +1348,7 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2016-12-19T20:04:51+00:00"
+            "time": "2016-12-19 20:04:51"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -1392,7 +1393,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-09-13T14:38:50+00:00"
+            "time": "2016-09-13 14:38:50"
         }
     ],
     "packages-dev": [],

--- a/src/Container/Symfony/Resource/CompiledPrototypeContainer.php
+++ b/src/Container/Symfony/Resource/CompiledPrototypeContainer.php
@@ -26,106 +26,106 @@ class CompiledPrototypeContainer extends Container
     {
         $this->services = array();
         $this->methodMap = array(
-            'dicontainerbenchmarks\\fixture\\class1' => 'getDicontainerbenchmarks_Fixture_Class1Service',
-            'dicontainerbenchmarks\\fixture\\class10' => 'getDicontainerbenchmarks_Fixture_Class10Service',
-            'dicontainerbenchmarks\\fixture\\class100' => 'getDicontainerbenchmarks_Fixture_Class100Service',
-            'dicontainerbenchmarks\\fixture\\class11' => 'getDicontainerbenchmarks_Fixture_Class11Service',
-            'dicontainerbenchmarks\\fixture\\class12' => 'getDicontainerbenchmarks_Fixture_Class12Service',
-            'dicontainerbenchmarks\\fixture\\class13' => 'getDicontainerbenchmarks_Fixture_Class13Service',
-            'dicontainerbenchmarks\\fixture\\class14' => 'getDicontainerbenchmarks_Fixture_Class14Service',
-            'dicontainerbenchmarks\\fixture\\class15' => 'getDicontainerbenchmarks_Fixture_Class15Service',
-            'dicontainerbenchmarks\\fixture\\class16' => 'getDicontainerbenchmarks_Fixture_Class16Service',
-            'dicontainerbenchmarks\\fixture\\class17' => 'getDicontainerbenchmarks_Fixture_Class17Service',
-            'dicontainerbenchmarks\\fixture\\class18' => 'getDicontainerbenchmarks_Fixture_Class18Service',
-            'dicontainerbenchmarks\\fixture\\class19' => 'getDicontainerbenchmarks_Fixture_Class19Service',
-            'dicontainerbenchmarks\\fixture\\class2' => 'getDicontainerbenchmarks_Fixture_Class2Service',
-            'dicontainerbenchmarks\\fixture\\class20' => 'getDicontainerbenchmarks_Fixture_Class20Service',
-            'dicontainerbenchmarks\\fixture\\class21' => 'getDicontainerbenchmarks_Fixture_Class21Service',
-            'dicontainerbenchmarks\\fixture\\class22' => 'getDicontainerbenchmarks_Fixture_Class22Service',
-            'dicontainerbenchmarks\\fixture\\class23' => 'getDicontainerbenchmarks_Fixture_Class23Service',
-            'dicontainerbenchmarks\\fixture\\class24' => 'getDicontainerbenchmarks_Fixture_Class24Service',
-            'dicontainerbenchmarks\\fixture\\class25' => 'getDicontainerbenchmarks_Fixture_Class25Service',
-            'dicontainerbenchmarks\\fixture\\class26' => 'getDicontainerbenchmarks_Fixture_Class26Service',
-            'dicontainerbenchmarks\\fixture\\class27' => 'getDicontainerbenchmarks_Fixture_Class27Service',
-            'dicontainerbenchmarks\\fixture\\class28' => 'getDicontainerbenchmarks_Fixture_Class28Service',
-            'dicontainerbenchmarks\\fixture\\class29' => 'getDicontainerbenchmarks_Fixture_Class29Service',
-            'dicontainerbenchmarks\\fixture\\class3' => 'getDicontainerbenchmarks_Fixture_Class3Service',
-            'dicontainerbenchmarks\\fixture\\class30' => 'getDicontainerbenchmarks_Fixture_Class30Service',
-            'dicontainerbenchmarks\\fixture\\class31' => 'getDicontainerbenchmarks_Fixture_Class31Service',
-            'dicontainerbenchmarks\\fixture\\class32' => 'getDicontainerbenchmarks_Fixture_Class32Service',
-            'dicontainerbenchmarks\\fixture\\class33' => 'getDicontainerbenchmarks_Fixture_Class33Service',
-            'dicontainerbenchmarks\\fixture\\class34' => 'getDicontainerbenchmarks_Fixture_Class34Service',
-            'dicontainerbenchmarks\\fixture\\class35' => 'getDicontainerbenchmarks_Fixture_Class35Service',
-            'dicontainerbenchmarks\\fixture\\class36' => 'getDicontainerbenchmarks_Fixture_Class36Service',
-            'dicontainerbenchmarks\\fixture\\class37' => 'getDicontainerbenchmarks_Fixture_Class37Service',
-            'dicontainerbenchmarks\\fixture\\class38' => 'getDicontainerbenchmarks_Fixture_Class38Service',
-            'dicontainerbenchmarks\\fixture\\class39' => 'getDicontainerbenchmarks_Fixture_Class39Service',
-            'dicontainerbenchmarks\\fixture\\class4' => 'getDicontainerbenchmarks_Fixture_Class4Service',
-            'dicontainerbenchmarks\\fixture\\class40' => 'getDicontainerbenchmarks_Fixture_Class40Service',
-            'dicontainerbenchmarks\\fixture\\class41' => 'getDicontainerbenchmarks_Fixture_Class41Service',
-            'dicontainerbenchmarks\\fixture\\class42' => 'getDicontainerbenchmarks_Fixture_Class42Service',
-            'dicontainerbenchmarks\\fixture\\class43' => 'getDicontainerbenchmarks_Fixture_Class43Service',
-            'dicontainerbenchmarks\\fixture\\class44' => 'getDicontainerbenchmarks_Fixture_Class44Service',
-            'dicontainerbenchmarks\\fixture\\class45' => 'getDicontainerbenchmarks_Fixture_Class45Service',
-            'dicontainerbenchmarks\\fixture\\class46' => 'getDicontainerbenchmarks_Fixture_Class46Service',
-            'dicontainerbenchmarks\\fixture\\class47' => 'getDicontainerbenchmarks_Fixture_Class47Service',
-            'dicontainerbenchmarks\\fixture\\class48' => 'getDicontainerbenchmarks_Fixture_Class48Service',
-            'dicontainerbenchmarks\\fixture\\class49' => 'getDicontainerbenchmarks_Fixture_Class49Service',
-            'dicontainerbenchmarks\\fixture\\class5' => 'getDicontainerbenchmarks_Fixture_Class5Service',
-            'dicontainerbenchmarks\\fixture\\class50' => 'getDicontainerbenchmarks_Fixture_Class50Service',
-            'dicontainerbenchmarks\\fixture\\class51' => 'getDicontainerbenchmarks_Fixture_Class51Service',
-            'dicontainerbenchmarks\\fixture\\class52' => 'getDicontainerbenchmarks_Fixture_Class52Service',
-            'dicontainerbenchmarks\\fixture\\class53' => 'getDicontainerbenchmarks_Fixture_Class53Service',
-            'dicontainerbenchmarks\\fixture\\class54' => 'getDicontainerbenchmarks_Fixture_Class54Service',
-            'dicontainerbenchmarks\\fixture\\class55' => 'getDicontainerbenchmarks_Fixture_Class55Service',
-            'dicontainerbenchmarks\\fixture\\class56' => 'getDicontainerbenchmarks_Fixture_Class56Service',
-            'dicontainerbenchmarks\\fixture\\class57' => 'getDicontainerbenchmarks_Fixture_Class57Service',
-            'dicontainerbenchmarks\\fixture\\class58' => 'getDicontainerbenchmarks_Fixture_Class58Service',
-            'dicontainerbenchmarks\\fixture\\class59' => 'getDicontainerbenchmarks_Fixture_Class59Service',
-            'dicontainerbenchmarks\\fixture\\class6' => 'getDicontainerbenchmarks_Fixture_Class6Service',
-            'dicontainerbenchmarks\\fixture\\class60' => 'getDicontainerbenchmarks_Fixture_Class60Service',
-            'dicontainerbenchmarks\\fixture\\class61' => 'getDicontainerbenchmarks_Fixture_Class61Service',
-            'dicontainerbenchmarks\\fixture\\class62' => 'getDicontainerbenchmarks_Fixture_Class62Service',
-            'dicontainerbenchmarks\\fixture\\class63' => 'getDicontainerbenchmarks_Fixture_Class63Service',
-            'dicontainerbenchmarks\\fixture\\class64' => 'getDicontainerbenchmarks_Fixture_Class64Service',
-            'dicontainerbenchmarks\\fixture\\class65' => 'getDicontainerbenchmarks_Fixture_Class65Service',
-            'dicontainerbenchmarks\\fixture\\class66' => 'getDicontainerbenchmarks_Fixture_Class66Service',
-            'dicontainerbenchmarks\\fixture\\class67' => 'getDicontainerbenchmarks_Fixture_Class67Service',
-            'dicontainerbenchmarks\\fixture\\class68' => 'getDicontainerbenchmarks_Fixture_Class68Service',
-            'dicontainerbenchmarks\\fixture\\class69' => 'getDicontainerbenchmarks_Fixture_Class69Service',
-            'dicontainerbenchmarks\\fixture\\class7' => 'getDicontainerbenchmarks_Fixture_Class7Service',
-            'dicontainerbenchmarks\\fixture\\class70' => 'getDicontainerbenchmarks_Fixture_Class70Service',
-            'dicontainerbenchmarks\\fixture\\class71' => 'getDicontainerbenchmarks_Fixture_Class71Service',
-            'dicontainerbenchmarks\\fixture\\class72' => 'getDicontainerbenchmarks_Fixture_Class72Service',
-            'dicontainerbenchmarks\\fixture\\class73' => 'getDicontainerbenchmarks_Fixture_Class73Service',
-            'dicontainerbenchmarks\\fixture\\class74' => 'getDicontainerbenchmarks_Fixture_Class74Service',
-            'dicontainerbenchmarks\\fixture\\class75' => 'getDicontainerbenchmarks_Fixture_Class75Service',
-            'dicontainerbenchmarks\\fixture\\class76' => 'getDicontainerbenchmarks_Fixture_Class76Service',
-            'dicontainerbenchmarks\\fixture\\class77' => 'getDicontainerbenchmarks_Fixture_Class77Service',
-            'dicontainerbenchmarks\\fixture\\class78' => 'getDicontainerbenchmarks_Fixture_Class78Service',
-            'dicontainerbenchmarks\\fixture\\class79' => 'getDicontainerbenchmarks_Fixture_Class79Service',
-            'dicontainerbenchmarks\\fixture\\class8' => 'getDicontainerbenchmarks_Fixture_Class8Service',
-            'dicontainerbenchmarks\\fixture\\class80' => 'getDicontainerbenchmarks_Fixture_Class80Service',
-            'dicontainerbenchmarks\\fixture\\class81' => 'getDicontainerbenchmarks_Fixture_Class81Service',
-            'dicontainerbenchmarks\\fixture\\class82' => 'getDicontainerbenchmarks_Fixture_Class82Service',
-            'dicontainerbenchmarks\\fixture\\class83' => 'getDicontainerbenchmarks_Fixture_Class83Service',
-            'dicontainerbenchmarks\\fixture\\class84' => 'getDicontainerbenchmarks_Fixture_Class84Service',
-            'dicontainerbenchmarks\\fixture\\class85' => 'getDicontainerbenchmarks_Fixture_Class85Service',
-            'dicontainerbenchmarks\\fixture\\class86' => 'getDicontainerbenchmarks_Fixture_Class86Service',
-            'dicontainerbenchmarks\\fixture\\class87' => 'getDicontainerbenchmarks_Fixture_Class87Service',
-            'dicontainerbenchmarks\\fixture\\class88' => 'getDicontainerbenchmarks_Fixture_Class88Service',
-            'dicontainerbenchmarks\\fixture\\class89' => 'getDicontainerbenchmarks_Fixture_Class89Service',
-            'dicontainerbenchmarks\\fixture\\class9' => 'getDicontainerbenchmarks_Fixture_Class9Service',
-            'dicontainerbenchmarks\\fixture\\class90' => 'getDicontainerbenchmarks_Fixture_Class90Service',
-            'dicontainerbenchmarks\\fixture\\class91' => 'getDicontainerbenchmarks_Fixture_Class91Service',
-            'dicontainerbenchmarks\\fixture\\class92' => 'getDicontainerbenchmarks_Fixture_Class92Service',
-            'dicontainerbenchmarks\\fixture\\class93' => 'getDicontainerbenchmarks_Fixture_Class93Service',
-            'dicontainerbenchmarks\\fixture\\class94' => 'getDicontainerbenchmarks_Fixture_Class94Service',
-            'dicontainerbenchmarks\\fixture\\class95' => 'getDicontainerbenchmarks_Fixture_Class95Service',
-            'dicontainerbenchmarks\\fixture\\class96' => 'getDicontainerbenchmarks_Fixture_Class96Service',
-            'dicontainerbenchmarks\\fixture\\class97' => 'getDicontainerbenchmarks_Fixture_Class97Service',
-            'dicontainerbenchmarks\\fixture\\class98' => 'getDicontainerbenchmarks_Fixture_Class98Service',
-            'dicontainerbenchmarks\\fixture\\class99' => 'getDicontainerbenchmarks_Fixture_Class99Service',
+            'class1' => 'getClass1Service',
+            'class10' => 'getClass10Service',
+            'class100' => 'getClass100Service',
+            'class11' => 'getClass11Service',
+            'class12' => 'getClass12Service',
+            'class13' => 'getClass13Service',
+            'class14' => 'getClass14Service',
+            'class15' => 'getClass15Service',
+            'class16' => 'getClass16Service',
+            'class17' => 'getClass17Service',
+            'class18' => 'getClass18Service',
+            'class19' => 'getClass19Service',
+            'class2' => 'getClass2Service',
+            'class20' => 'getClass20Service',
+            'class21' => 'getClass21Service',
+            'class22' => 'getClass22Service',
+            'class23' => 'getClass23Service',
+            'class24' => 'getClass24Service',
+            'class25' => 'getClass25Service',
+            'class26' => 'getClass26Service',
+            'class27' => 'getClass27Service',
+            'class28' => 'getClass28Service',
+            'class29' => 'getClass29Service',
+            'class3' => 'getClass3Service',
+            'class30' => 'getClass30Service',
+            'class31' => 'getClass31Service',
+            'class32' => 'getClass32Service',
+            'class33' => 'getClass33Service',
+            'class34' => 'getClass34Service',
+            'class35' => 'getClass35Service',
+            'class36' => 'getClass36Service',
+            'class37' => 'getClass37Service',
+            'class38' => 'getClass38Service',
+            'class39' => 'getClass39Service',
+            'class4' => 'getClass4Service',
+            'class40' => 'getClass40Service',
+            'class41' => 'getClass41Service',
+            'class42' => 'getClass42Service',
+            'class43' => 'getClass43Service',
+            'class44' => 'getClass44Service',
+            'class45' => 'getClass45Service',
+            'class46' => 'getClass46Service',
+            'class47' => 'getClass47Service',
+            'class48' => 'getClass48Service',
+            'class49' => 'getClass49Service',
+            'class5' => 'getClass5Service',
+            'class50' => 'getClass50Service',
+            'class51' => 'getClass51Service',
+            'class52' => 'getClass52Service',
+            'class53' => 'getClass53Service',
+            'class54' => 'getClass54Service',
+            'class55' => 'getClass55Service',
+            'class56' => 'getClass56Service',
+            'class57' => 'getClass57Service',
+            'class58' => 'getClass58Service',
+            'class59' => 'getClass59Service',
+            'class6' => 'getClass6Service',
+            'class60' => 'getClass60Service',
+            'class61' => 'getClass61Service',
+            'class62' => 'getClass62Service',
+            'class63' => 'getClass63Service',
+            'class64' => 'getClass64Service',
+            'class65' => 'getClass65Service',
+            'class66' => 'getClass66Service',
+            'class67' => 'getClass67Service',
+            'class68' => 'getClass68Service',
+            'class69' => 'getClass69Service',
+            'class7' => 'getClass7Service',
+            'class70' => 'getClass70Service',
+            'class71' => 'getClass71Service',
+            'class72' => 'getClass72Service',
+            'class73' => 'getClass73Service',
+            'class74' => 'getClass74Service',
+            'class75' => 'getClass75Service',
+            'class76' => 'getClass76Service',
+            'class77' => 'getClass77Service',
+            'class78' => 'getClass78Service',
+            'class79' => 'getClass79Service',
+            'class8' => 'getClass8Service',
+            'class80' => 'getClass80Service',
+            'class81' => 'getClass81Service',
+            'class82' => 'getClass82Service',
+            'class83' => 'getClass83Service',
+            'class84' => 'getClass84Service',
+            'class85' => 'getClass85Service',
+            'class86' => 'getClass86Service',
+            'class87' => 'getClass87Service',
+            'class88' => 'getClass88Service',
+            'class89' => 'getClass89Service',
+            'class9' => 'getClass9Service',
+            'class90' => 'getClass90Service',
+            'class91' => 'getClass91Service',
+            'class92' => 'getClass92Service',
+            'class93' => 'getClass93Service',
+            'class94' => 'getClass94Service',
+            'class95' => 'getClass95Service',
+            'class96' => 'getClass96Service',
+            'class97' => 'getClass97Service',
+            'class98' => 'getClass98Service',
+            'class99' => 'getClass99Service',
         );
 
         $this->aliases = array();
@@ -148,1201 +148,1201 @@ class CompiledPrototypeContainer extends Container
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class1' service.
+     * Gets the 'class1' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class1 A DiContainerBenchmarks\Fixture\Class1 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class1Service()
+    protected function getClass1Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class1();
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class10' service.
+     * Gets the 'class10' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class10 A DiContainerBenchmarks\Fixture\Class10 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class10Service()
+    protected function getClass10Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class100' service.
+     * Gets the 'class100' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class100 A DiContainerBenchmarks\Fixture\Class100 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class100Service()
+    protected function getClass100Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class100(new \DiContainerBenchmarks\Fixture\Class99(new \DiContainerBenchmarks\Fixture\Class98(new \DiContainerBenchmarks\Fixture\Class97(new \DiContainerBenchmarks\Fixture\Class96(new \DiContainerBenchmarks\Fixture\Class95(new \DiContainerBenchmarks\Fixture\Class94(new \DiContainerBenchmarks\Fixture\Class93(new \DiContainerBenchmarks\Fixture\Class92(new \DiContainerBenchmarks\Fixture\Class91(new \DiContainerBenchmarks\Fixture\Class90(new \DiContainerBenchmarks\Fixture\Class89(new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class11' service.
+     * Gets the 'class11' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class11 A DiContainerBenchmarks\Fixture\Class11 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class11Service()
+    protected function getClass11Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class12' service.
+     * Gets the 'class12' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class12 A DiContainerBenchmarks\Fixture\Class12 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class12Service()
+    protected function getClass12Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class13' service.
+     * Gets the 'class13' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class13 A DiContainerBenchmarks\Fixture\Class13 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class13Service()
+    protected function getClass13Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class14' service.
+     * Gets the 'class14' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class14 A DiContainerBenchmarks\Fixture\Class14 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class14Service()
+    protected function getClass14Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class15' service.
+     * Gets the 'class15' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class15 A DiContainerBenchmarks\Fixture\Class15 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class15Service()
+    protected function getClass15Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class16' service.
+     * Gets the 'class16' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class16 A DiContainerBenchmarks\Fixture\Class16 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class16Service()
+    protected function getClass16Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class17' service.
+     * Gets the 'class17' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class17 A DiContainerBenchmarks\Fixture\Class17 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class17Service()
+    protected function getClass17Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class18' service.
+     * Gets the 'class18' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class18 A DiContainerBenchmarks\Fixture\Class18 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class18Service()
+    protected function getClass18Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class19' service.
+     * Gets the 'class19' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class19 A DiContainerBenchmarks\Fixture\Class19 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class19Service()
+    protected function getClass19Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class2' service.
+     * Gets the 'class2' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class2 A DiContainerBenchmarks\Fixture\Class2 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class2Service()
+    protected function getClass2Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1());
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class20' service.
+     * Gets the 'class20' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class20 A DiContainerBenchmarks\Fixture\Class20 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class20Service()
+    protected function getClass20Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class21' service.
+     * Gets the 'class21' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class21 A DiContainerBenchmarks\Fixture\Class21 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class21Service()
+    protected function getClass21Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class22' service.
+     * Gets the 'class22' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class22 A DiContainerBenchmarks\Fixture\Class22 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class22Service()
+    protected function getClass22Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class23' service.
+     * Gets the 'class23' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class23 A DiContainerBenchmarks\Fixture\Class23 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class23Service()
+    protected function getClass23Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class24' service.
+     * Gets the 'class24' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class24 A DiContainerBenchmarks\Fixture\Class24 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class24Service()
+    protected function getClass24Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class25' service.
+     * Gets the 'class25' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class25 A DiContainerBenchmarks\Fixture\Class25 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class25Service()
+    protected function getClass25Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class26' service.
+     * Gets the 'class26' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class26 A DiContainerBenchmarks\Fixture\Class26 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class26Service()
+    protected function getClass26Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class27' service.
+     * Gets the 'class27' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class27 A DiContainerBenchmarks\Fixture\Class27 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class27Service()
+    protected function getClass27Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class28' service.
+     * Gets the 'class28' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class28 A DiContainerBenchmarks\Fixture\Class28 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class28Service()
+    protected function getClass28Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class29' service.
+     * Gets the 'class29' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class29 A DiContainerBenchmarks\Fixture\Class29 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class29Service()
+    protected function getClass29Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class3' service.
+     * Gets the 'class3' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class3 A DiContainerBenchmarks\Fixture\Class3 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class3Service()
+    protected function getClass3Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class30' service.
+     * Gets the 'class30' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class30 A DiContainerBenchmarks\Fixture\Class30 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class30Service()
+    protected function getClass30Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class31' service.
+     * Gets the 'class31' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class31 A DiContainerBenchmarks\Fixture\Class31 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class31Service()
+    protected function getClass31Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class32' service.
+     * Gets the 'class32' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class32 A DiContainerBenchmarks\Fixture\Class32 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class32Service()
+    protected function getClass32Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class33' service.
+     * Gets the 'class33' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class33 A DiContainerBenchmarks\Fixture\Class33 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class33Service()
+    protected function getClass33Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class34' service.
+     * Gets the 'class34' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class34 A DiContainerBenchmarks\Fixture\Class34 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class34Service()
+    protected function getClass34Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class35' service.
+     * Gets the 'class35' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class35 A DiContainerBenchmarks\Fixture\Class35 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class35Service()
+    protected function getClass35Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class36' service.
+     * Gets the 'class36' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class36 A DiContainerBenchmarks\Fixture\Class36 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class36Service()
+    protected function getClass36Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class37' service.
+     * Gets the 'class37' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class37 A DiContainerBenchmarks\Fixture\Class37 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class37Service()
+    protected function getClass37Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class38' service.
+     * Gets the 'class38' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class38 A DiContainerBenchmarks\Fixture\Class38 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class38Service()
+    protected function getClass38Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class39' service.
+     * Gets the 'class39' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class39 A DiContainerBenchmarks\Fixture\Class39 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class39Service()
+    protected function getClass39Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class4' service.
+     * Gets the 'class4' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class4 A DiContainerBenchmarks\Fixture\Class4 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class4Service()
+    protected function getClass4Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class40' service.
+     * Gets the 'class40' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class40 A DiContainerBenchmarks\Fixture\Class40 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class40Service()
+    protected function getClass40Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class41' service.
+     * Gets the 'class41' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class41 A DiContainerBenchmarks\Fixture\Class41 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class41Service()
+    protected function getClass41Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class42' service.
+     * Gets the 'class42' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class42 A DiContainerBenchmarks\Fixture\Class42 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class42Service()
+    protected function getClass42Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class43' service.
+     * Gets the 'class43' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class43 A DiContainerBenchmarks\Fixture\Class43 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class43Service()
+    protected function getClass43Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class44' service.
+     * Gets the 'class44' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class44 A DiContainerBenchmarks\Fixture\Class44 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class44Service()
+    protected function getClass44Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class45' service.
+     * Gets the 'class45' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class45 A DiContainerBenchmarks\Fixture\Class45 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class45Service()
+    protected function getClass45Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class46' service.
+     * Gets the 'class46' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class46 A DiContainerBenchmarks\Fixture\Class46 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class46Service()
+    protected function getClass46Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class47' service.
+     * Gets the 'class47' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class47 A DiContainerBenchmarks\Fixture\Class47 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class47Service()
+    protected function getClass47Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class48' service.
+     * Gets the 'class48' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class48 A DiContainerBenchmarks\Fixture\Class48 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class48Service()
+    protected function getClass48Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class49' service.
+     * Gets the 'class49' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class49 A DiContainerBenchmarks\Fixture\Class49 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class49Service()
+    protected function getClass49Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class5' service.
+     * Gets the 'class5' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class5 A DiContainerBenchmarks\Fixture\Class5 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class5Service()
+    protected function getClass5Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class50' service.
+     * Gets the 'class50' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class50 A DiContainerBenchmarks\Fixture\Class50 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class50Service()
+    protected function getClass50Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class51' service.
+     * Gets the 'class51' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class51 A DiContainerBenchmarks\Fixture\Class51 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class51Service()
+    protected function getClass51Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class52' service.
+     * Gets the 'class52' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class52 A DiContainerBenchmarks\Fixture\Class52 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class52Service()
+    protected function getClass52Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class53' service.
+     * Gets the 'class53' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class53 A DiContainerBenchmarks\Fixture\Class53 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class53Service()
+    protected function getClass53Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class54' service.
+     * Gets the 'class54' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class54 A DiContainerBenchmarks\Fixture\Class54 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class54Service()
+    protected function getClass54Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class55' service.
+     * Gets the 'class55' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class55 A DiContainerBenchmarks\Fixture\Class55 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class55Service()
+    protected function getClass55Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class56' service.
+     * Gets the 'class56' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class56 A DiContainerBenchmarks\Fixture\Class56 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class56Service()
+    protected function getClass56Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class57' service.
+     * Gets the 'class57' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class57 A DiContainerBenchmarks\Fixture\Class57 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class57Service()
+    protected function getClass57Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class58' service.
+     * Gets the 'class58' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class58 A DiContainerBenchmarks\Fixture\Class58 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class58Service()
+    protected function getClass58Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class59' service.
+     * Gets the 'class59' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class59 A DiContainerBenchmarks\Fixture\Class59 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class59Service()
+    protected function getClass59Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class6' service.
+     * Gets the 'class6' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class6 A DiContainerBenchmarks\Fixture\Class6 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class6Service()
+    protected function getClass6Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class60' service.
+     * Gets the 'class60' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class60 A DiContainerBenchmarks\Fixture\Class60 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class60Service()
+    protected function getClass60Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class61' service.
+     * Gets the 'class61' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class61 A DiContainerBenchmarks\Fixture\Class61 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class61Service()
+    protected function getClass61Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class62' service.
+     * Gets the 'class62' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class62 A DiContainerBenchmarks\Fixture\Class62 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class62Service()
+    protected function getClass62Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class63' service.
+     * Gets the 'class63' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class63 A DiContainerBenchmarks\Fixture\Class63 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class63Service()
+    protected function getClass63Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class64' service.
+     * Gets the 'class64' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class64 A DiContainerBenchmarks\Fixture\Class64 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class64Service()
+    protected function getClass64Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class65' service.
+     * Gets the 'class65' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class65 A DiContainerBenchmarks\Fixture\Class65 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class65Service()
+    protected function getClass65Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class66' service.
+     * Gets the 'class66' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class66 A DiContainerBenchmarks\Fixture\Class66 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class66Service()
+    protected function getClass66Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class67' service.
+     * Gets the 'class67' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class67 A DiContainerBenchmarks\Fixture\Class67 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class67Service()
+    protected function getClass67Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class68' service.
+     * Gets the 'class68' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class68 A DiContainerBenchmarks\Fixture\Class68 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class68Service()
+    protected function getClass68Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class69' service.
+     * Gets the 'class69' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class69 A DiContainerBenchmarks\Fixture\Class69 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class69Service()
+    protected function getClass69Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class7' service.
+     * Gets the 'class7' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class7 A DiContainerBenchmarks\Fixture\Class7 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class7Service()
+    protected function getClass7Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class70' service.
+     * Gets the 'class70' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class70 A DiContainerBenchmarks\Fixture\Class70 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class70Service()
+    protected function getClass70Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class71' service.
+     * Gets the 'class71' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class71 A DiContainerBenchmarks\Fixture\Class71 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class71Service()
+    protected function getClass71Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class72' service.
+     * Gets the 'class72' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class72 A DiContainerBenchmarks\Fixture\Class72 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class72Service()
+    protected function getClass72Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class73' service.
+     * Gets the 'class73' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class73 A DiContainerBenchmarks\Fixture\Class73 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class73Service()
+    protected function getClass73Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class74' service.
+     * Gets the 'class74' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class74 A DiContainerBenchmarks\Fixture\Class74 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class74Service()
+    protected function getClass74Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class75' service.
+     * Gets the 'class75' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class75 A DiContainerBenchmarks\Fixture\Class75 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class75Service()
+    protected function getClass75Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class76' service.
+     * Gets the 'class76' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class76 A DiContainerBenchmarks\Fixture\Class76 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class76Service()
+    protected function getClass76Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class77' service.
+     * Gets the 'class77' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class77 A DiContainerBenchmarks\Fixture\Class77 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class77Service()
+    protected function getClass77Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class78' service.
+     * Gets the 'class78' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class78 A DiContainerBenchmarks\Fixture\Class78 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class78Service()
+    protected function getClass78Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class79' service.
+     * Gets the 'class79' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class79 A DiContainerBenchmarks\Fixture\Class79 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class79Service()
+    protected function getClass79Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class8' service.
+     * Gets the 'class8' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class8 A DiContainerBenchmarks\Fixture\Class8 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class8Service()
+    protected function getClass8Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class80' service.
+     * Gets the 'class80' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class80 A DiContainerBenchmarks\Fixture\Class80 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class80Service()
+    protected function getClass80Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class81' service.
+     * Gets the 'class81' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class81 A DiContainerBenchmarks\Fixture\Class81 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class81Service()
+    protected function getClass81Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class82' service.
+     * Gets the 'class82' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class82 A DiContainerBenchmarks\Fixture\Class82 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class82Service()
+    protected function getClass82Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class83' service.
+     * Gets the 'class83' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class83 A DiContainerBenchmarks\Fixture\Class83 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class83Service()
+    protected function getClass83Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class84' service.
+     * Gets the 'class84' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class84 A DiContainerBenchmarks\Fixture\Class84 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class84Service()
+    protected function getClass84Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class85' service.
+     * Gets the 'class85' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class85 A DiContainerBenchmarks\Fixture\Class85 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class85Service()
+    protected function getClass85Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class86' service.
+     * Gets the 'class86' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class86 A DiContainerBenchmarks\Fixture\Class86 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class86Service()
+    protected function getClass86Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class87' service.
+     * Gets the 'class87' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class87 A DiContainerBenchmarks\Fixture\Class87 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class87Service()
+    protected function getClass87Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class88' service.
+     * Gets the 'class88' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class88 A DiContainerBenchmarks\Fixture\Class88 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class88Service()
+    protected function getClass88Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class89' service.
+     * Gets the 'class89' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class89 A DiContainerBenchmarks\Fixture\Class89 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class89Service()
+    protected function getClass89Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class89(new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class9' service.
+     * Gets the 'class9' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class9 A DiContainerBenchmarks\Fixture\Class9 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class9Service()
+    protected function getClass9Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class90' service.
+     * Gets the 'class90' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class90 A DiContainerBenchmarks\Fixture\Class90 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class90Service()
+    protected function getClass90Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class90(new \DiContainerBenchmarks\Fixture\Class89(new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class91' service.
+     * Gets the 'class91' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class91 A DiContainerBenchmarks\Fixture\Class91 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class91Service()
+    protected function getClass91Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class91(new \DiContainerBenchmarks\Fixture\Class90(new \DiContainerBenchmarks\Fixture\Class89(new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class92' service.
+     * Gets the 'class92' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class92 A DiContainerBenchmarks\Fixture\Class92 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class92Service()
+    protected function getClass92Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class92(new \DiContainerBenchmarks\Fixture\Class91(new \DiContainerBenchmarks\Fixture\Class90(new \DiContainerBenchmarks\Fixture\Class89(new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class93' service.
+     * Gets the 'class93' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class93 A DiContainerBenchmarks\Fixture\Class93 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class93Service()
+    protected function getClass93Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class93(new \DiContainerBenchmarks\Fixture\Class92(new \DiContainerBenchmarks\Fixture\Class91(new \DiContainerBenchmarks\Fixture\Class90(new \DiContainerBenchmarks\Fixture\Class89(new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class94' service.
+     * Gets the 'class94' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class94 A DiContainerBenchmarks\Fixture\Class94 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class94Service()
+    protected function getClass94Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class94(new \DiContainerBenchmarks\Fixture\Class93(new \DiContainerBenchmarks\Fixture\Class92(new \DiContainerBenchmarks\Fixture\Class91(new \DiContainerBenchmarks\Fixture\Class90(new \DiContainerBenchmarks\Fixture\Class89(new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class95' service.
+     * Gets the 'class95' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class95 A DiContainerBenchmarks\Fixture\Class95 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class95Service()
+    protected function getClass95Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class95(new \DiContainerBenchmarks\Fixture\Class94(new \DiContainerBenchmarks\Fixture\Class93(new \DiContainerBenchmarks\Fixture\Class92(new \DiContainerBenchmarks\Fixture\Class91(new \DiContainerBenchmarks\Fixture\Class90(new \DiContainerBenchmarks\Fixture\Class89(new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class96' service.
+     * Gets the 'class96' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class96 A DiContainerBenchmarks\Fixture\Class96 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class96Service()
+    protected function getClass96Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class96(new \DiContainerBenchmarks\Fixture\Class95(new \DiContainerBenchmarks\Fixture\Class94(new \DiContainerBenchmarks\Fixture\Class93(new \DiContainerBenchmarks\Fixture\Class92(new \DiContainerBenchmarks\Fixture\Class91(new \DiContainerBenchmarks\Fixture\Class90(new \DiContainerBenchmarks\Fixture\Class89(new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class97' service.
+     * Gets the 'class97' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class97 A DiContainerBenchmarks\Fixture\Class97 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class97Service()
+    protected function getClass97Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class97(new \DiContainerBenchmarks\Fixture\Class96(new \DiContainerBenchmarks\Fixture\Class95(new \DiContainerBenchmarks\Fixture\Class94(new \DiContainerBenchmarks\Fixture\Class93(new \DiContainerBenchmarks\Fixture\Class92(new \DiContainerBenchmarks\Fixture\Class91(new \DiContainerBenchmarks\Fixture\Class90(new \DiContainerBenchmarks\Fixture\Class89(new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class98' service.
+     * Gets the 'class98' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class98 A DiContainerBenchmarks\Fixture\Class98 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class98Service()
+    protected function getClass98Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class98(new \DiContainerBenchmarks\Fixture\Class97(new \DiContainerBenchmarks\Fixture\Class96(new \DiContainerBenchmarks\Fixture\Class95(new \DiContainerBenchmarks\Fixture\Class94(new \DiContainerBenchmarks\Fixture\Class93(new \DiContainerBenchmarks\Fixture\Class92(new \DiContainerBenchmarks\Fixture\Class91(new \DiContainerBenchmarks\Fixture\Class90(new \DiContainerBenchmarks\Fixture\Class89(new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1())))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class99' service.
+     * Gets the 'class99' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class99 A DiContainerBenchmarks\Fixture\Class99 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class99Service()
+    protected function getClass99Service()
     {
         return new \DiContainerBenchmarks\Fixture\Class99(new \DiContainerBenchmarks\Fixture\Class98(new \DiContainerBenchmarks\Fixture\Class97(new \DiContainerBenchmarks\Fixture\Class96(new \DiContainerBenchmarks\Fixture\Class95(new \DiContainerBenchmarks\Fixture\Class94(new \DiContainerBenchmarks\Fixture\Class93(new \DiContainerBenchmarks\Fixture\Class92(new \DiContainerBenchmarks\Fixture\Class91(new \DiContainerBenchmarks\Fixture\Class90(new \DiContainerBenchmarks\Fixture\Class89(new \DiContainerBenchmarks\Fixture\Class88(new \DiContainerBenchmarks\Fixture\Class87(new \DiContainerBenchmarks\Fixture\Class86(new \DiContainerBenchmarks\Fixture\Class85(new \DiContainerBenchmarks\Fixture\Class84(new \DiContainerBenchmarks\Fixture\Class83(new \DiContainerBenchmarks\Fixture\Class82(new \DiContainerBenchmarks\Fixture\Class81(new \DiContainerBenchmarks\Fixture\Class80(new \DiContainerBenchmarks\Fixture\Class79(new \DiContainerBenchmarks\Fixture\Class78(new \DiContainerBenchmarks\Fixture\Class77(new \DiContainerBenchmarks\Fixture\Class76(new \DiContainerBenchmarks\Fixture\Class75(new \DiContainerBenchmarks\Fixture\Class74(new \DiContainerBenchmarks\Fixture\Class73(new \DiContainerBenchmarks\Fixture\Class72(new \DiContainerBenchmarks\Fixture\Class71(new \DiContainerBenchmarks\Fixture\Class70(new \DiContainerBenchmarks\Fixture\Class69(new \DiContainerBenchmarks\Fixture\Class68(new \DiContainerBenchmarks\Fixture\Class67(new \DiContainerBenchmarks\Fixture\Class66(new \DiContainerBenchmarks\Fixture\Class65(new \DiContainerBenchmarks\Fixture\Class64(new \DiContainerBenchmarks\Fixture\Class63(new \DiContainerBenchmarks\Fixture\Class62(new \DiContainerBenchmarks\Fixture\Class61(new \DiContainerBenchmarks\Fixture\Class60(new \DiContainerBenchmarks\Fixture\Class59(new \DiContainerBenchmarks\Fixture\Class58(new \DiContainerBenchmarks\Fixture\Class57(new \DiContainerBenchmarks\Fixture\Class56(new \DiContainerBenchmarks\Fixture\Class55(new \DiContainerBenchmarks\Fixture\Class54(new \DiContainerBenchmarks\Fixture\Class53(new \DiContainerBenchmarks\Fixture\Class52(new \DiContainerBenchmarks\Fixture\Class51(new \DiContainerBenchmarks\Fixture\Class50(new \DiContainerBenchmarks\Fixture\Class49(new \DiContainerBenchmarks\Fixture\Class48(new \DiContainerBenchmarks\Fixture\Class47(new \DiContainerBenchmarks\Fixture\Class46(new \DiContainerBenchmarks\Fixture\Class45(new \DiContainerBenchmarks\Fixture\Class44(new \DiContainerBenchmarks\Fixture\Class43(new \DiContainerBenchmarks\Fixture\Class42(new \DiContainerBenchmarks\Fixture\Class41(new \DiContainerBenchmarks\Fixture\Class40(new \DiContainerBenchmarks\Fixture\Class39(new \DiContainerBenchmarks\Fixture\Class38(new \DiContainerBenchmarks\Fixture\Class37(new \DiContainerBenchmarks\Fixture\Class36(new \DiContainerBenchmarks\Fixture\Class35(new \DiContainerBenchmarks\Fixture\Class34(new \DiContainerBenchmarks\Fixture\Class33(new \DiContainerBenchmarks\Fixture\Class32(new \DiContainerBenchmarks\Fixture\Class31(new \DiContainerBenchmarks\Fixture\Class30(new \DiContainerBenchmarks\Fixture\Class29(new \DiContainerBenchmarks\Fixture\Class28(new \DiContainerBenchmarks\Fixture\Class27(new \DiContainerBenchmarks\Fixture\Class26(new \DiContainerBenchmarks\Fixture\Class25(new \DiContainerBenchmarks\Fixture\Class24(new \DiContainerBenchmarks\Fixture\Class23(new \DiContainerBenchmarks\Fixture\Class22(new \DiContainerBenchmarks\Fixture\Class21(new \DiContainerBenchmarks\Fixture\Class20(new \DiContainerBenchmarks\Fixture\Class19(new \DiContainerBenchmarks\Fixture\Class18(new \DiContainerBenchmarks\Fixture\Class17(new \DiContainerBenchmarks\Fixture\Class16(new \DiContainerBenchmarks\Fixture\Class15(new \DiContainerBenchmarks\Fixture\Class14(new \DiContainerBenchmarks\Fixture\Class13(new \DiContainerBenchmarks\Fixture\Class12(new \DiContainerBenchmarks\Fixture\Class11(new \DiContainerBenchmarks\Fixture\Class10(new \DiContainerBenchmarks\Fixture\Class9(new \DiContainerBenchmarks\Fixture\Class8(new \DiContainerBenchmarks\Fixture\Class7(new \DiContainerBenchmarks\Fixture\Class6(new \DiContainerBenchmarks\Fixture\Class5(new \DiContainerBenchmarks\Fixture\Class4(new \DiContainerBenchmarks\Fixture\Class3(new \DiContainerBenchmarks\Fixture\Class2(new \DiContainerBenchmarks\Fixture\Class1()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
     }

--- a/src/Container/Symfony/Resource/CompiledSingletonContainer.php
+++ b/src/Container/Symfony/Resource/CompiledSingletonContainer.php
@@ -26,106 +26,106 @@ class CompiledSingletonContainer extends Container
     {
         $this->services = array();
         $this->methodMap = array(
-            'dicontainerbenchmarks\\fixture\\class1' => 'getDicontainerbenchmarks_Fixture_Class1Service',
-            'dicontainerbenchmarks\\fixture\\class10' => 'getDicontainerbenchmarks_Fixture_Class10Service',
-            'dicontainerbenchmarks\\fixture\\class100' => 'getDicontainerbenchmarks_Fixture_Class100Service',
-            'dicontainerbenchmarks\\fixture\\class11' => 'getDicontainerbenchmarks_Fixture_Class11Service',
-            'dicontainerbenchmarks\\fixture\\class12' => 'getDicontainerbenchmarks_Fixture_Class12Service',
-            'dicontainerbenchmarks\\fixture\\class13' => 'getDicontainerbenchmarks_Fixture_Class13Service',
-            'dicontainerbenchmarks\\fixture\\class14' => 'getDicontainerbenchmarks_Fixture_Class14Service',
-            'dicontainerbenchmarks\\fixture\\class15' => 'getDicontainerbenchmarks_Fixture_Class15Service',
-            'dicontainerbenchmarks\\fixture\\class16' => 'getDicontainerbenchmarks_Fixture_Class16Service',
-            'dicontainerbenchmarks\\fixture\\class17' => 'getDicontainerbenchmarks_Fixture_Class17Service',
-            'dicontainerbenchmarks\\fixture\\class18' => 'getDicontainerbenchmarks_Fixture_Class18Service',
-            'dicontainerbenchmarks\\fixture\\class19' => 'getDicontainerbenchmarks_Fixture_Class19Service',
-            'dicontainerbenchmarks\\fixture\\class2' => 'getDicontainerbenchmarks_Fixture_Class2Service',
-            'dicontainerbenchmarks\\fixture\\class20' => 'getDicontainerbenchmarks_Fixture_Class20Service',
-            'dicontainerbenchmarks\\fixture\\class21' => 'getDicontainerbenchmarks_Fixture_Class21Service',
-            'dicontainerbenchmarks\\fixture\\class22' => 'getDicontainerbenchmarks_Fixture_Class22Service',
-            'dicontainerbenchmarks\\fixture\\class23' => 'getDicontainerbenchmarks_Fixture_Class23Service',
-            'dicontainerbenchmarks\\fixture\\class24' => 'getDicontainerbenchmarks_Fixture_Class24Service',
-            'dicontainerbenchmarks\\fixture\\class25' => 'getDicontainerbenchmarks_Fixture_Class25Service',
-            'dicontainerbenchmarks\\fixture\\class26' => 'getDicontainerbenchmarks_Fixture_Class26Service',
-            'dicontainerbenchmarks\\fixture\\class27' => 'getDicontainerbenchmarks_Fixture_Class27Service',
-            'dicontainerbenchmarks\\fixture\\class28' => 'getDicontainerbenchmarks_Fixture_Class28Service',
-            'dicontainerbenchmarks\\fixture\\class29' => 'getDicontainerbenchmarks_Fixture_Class29Service',
-            'dicontainerbenchmarks\\fixture\\class3' => 'getDicontainerbenchmarks_Fixture_Class3Service',
-            'dicontainerbenchmarks\\fixture\\class30' => 'getDicontainerbenchmarks_Fixture_Class30Service',
-            'dicontainerbenchmarks\\fixture\\class31' => 'getDicontainerbenchmarks_Fixture_Class31Service',
-            'dicontainerbenchmarks\\fixture\\class32' => 'getDicontainerbenchmarks_Fixture_Class32Service',
-            'dicontainerbenchmarks\\fixture\\class33' => 'getDicontainerbenchmarks_Fixture_Class33Service',
-            'dicontainerbenchmarks\\fixture\\class34' => 'getDicontainerbenchmarks_Fixture_Class34Service',
-            'dicontainerbenchmarks\\fixture\\class35' => 'getDicontainerbenchmarks_Fixture_Class35Service',
-            'dicontainerbenchmarks\\fixture\\class36' => 'getDicontainerbenchmarks_Fixture_Class36Service',
-            'dicontainerbenchmarks\\fixture\\class37' => 'getDicontainerbenchmarks_Fixture_Class37Service',
-            'dicontainerbenchmarks\\fixture\\class38' => 'getDicontainerbenchmarks_Fixture_Class38Service',
-            'dicontainerbenchmarks\\fixture\\class39' => 'getDicontainerbenchmarks_Fixture_Class39Service',
-            'dicontainerbenchmarks\\fixture\\class4' => 'getDicontainerbenchmarks_Fixture_Class4Service',
-            'dicontainerbenchmarks\\fixture\\class40' => 'getDicontainerbenchmarks_Fixture_Class40Service',
-            'dicontainerbenchmarks\\fixture\\class41' => 'getDicontainerbenchmarks_Fixture_Class41Service',
-            'dicontainerbenchmarks\\fixture\\class42' => 'getDicontainerbenchmarks_Fixture_Class42Service',
-            'dicontainerbenchmarks\\fixture\\class43' => 'getDicontainerbenchmarks_Fixture_Class43Service',
-            'dicontainerbenchmarks\\fixture\\class44' => 'getDicontainerbenchmarks_Fixture_Class44Service',
-            'dicontainerbenchmarks\\fixture\\class45' => 'getDicontainerbenchmarks_Fixture_Class45Service',
-            'dicontainerbenchmarks\\fixture\\class46' => 'getDicontainerbenchmarks_Fixture_Class46Service',
-            'dicontainerbenchmarks\\fixture\\class47' => 'getDicontainerbenchmarks_Fixture_Class47Service',
-            'dicontainerbenchmarks\\fixture\\class48' => 'getDicontainerbenchmarks_Fixture_Class48Service',
-            'dicontainerbenchmarks\\fixture\\class49' => 'getDicontainerbenchmarks_Fixture_Class49Service',
-            'dicontainerbenchmarks\\fixture\\class5' => 'getDicontainerbenchmarks_Fixture_Class5Service',
-            'dicontainerbenchmarks\\fixture\\class50' => 'getDicontainerbenchmarks_Fixture_Class50Service',
-            'dicontainerbenchmarks\\fixture\\class51' => 'getDicontainerbenchmarks_Fixture_Class51Service',
-            'dicontainerbenchmarks\\fixture\\class52' => 'getDicontainerbenchmarks_Fixture_Class52Service',
-            'dicontainerbenchmarks\\fixture\\class53' => 'getDicontainerbenchmarks_Fixture_Class53Service',
-            'dicontainerbenchmarks\\fixture\\class54' => 'getDicontainerbenchmarks_Fixture_Class54Service',
-            'dicontainerbenchmarks\\fixture\\class55' => 'getDicontainerbenchmarks_Fixture_Class55Service',
-            'dicontainerbenchmarks\\fixture\\class56' => 'getDicontainerbenchmarks_Fixture_Class56Service',
-            'dicontainerbenchmarks\\fixture\\class57' => 'getDicontainerbenchmarks_Fixture_Class57Service',
-            'dicontainerbenchmarks\\fixture\\class58' => 'getDicontainerbenchmarks_Fixture_Class58Service',
-            'dicontainerbenchmarks\\fixture\\class59' => 'getDicontainerbenchmarks_Fixture_Class59Service',
-            'dicontainerbenchmarks\\fixture\\class6' => 'getDicontainerbenchmarks_Fixture_Class6Service',
-            'dicontainerbenchmarks\\fixture\\class60' => 'getDicontainerbenchmarks_Fixture_Class60Service',
-            'dicontainerbenchmarks\\fixture\\class61' => 'getDicontainerbenchmarks_Fixture_Class61Service',
-            'dicontainerbenchmarks\\fixture\\class62' => 'getDicontainerbenchmarks_Fixture_Class62Service',
-            'dicontainerbenchmarks\\fixture\\class63' => 'getDicontainerbenchmarks_Fixture_Class63Service',
-            'dicontainerbenchmarks\\fixture\\class64' => 'getDicontainerbenchmarks_Fixture_Class64Service',
-            'dicontainerbenchmarks\\fixture\\class65' => 'getDicontainerbenchmarks_Fixture_Class65Service',
-            'dicontainerbenchmarks\\fixture\\class66' => 'getDicontainerbenchmarks_Fixture_Class66Service',
-            'dicontainerbenchmarks\\fixture\\class67' => 'getDicontainerbenchmarks_Fixture_Class67Service',
-            'dicontainerbenchmarks\\fixture\\class68' => 'getDicontainerbenchmarks_Fixture_Class68Service',
-            'dicontainerbenchmarks\\fixture\\class69' => 'getDicontainerbenchmarks_Fixture_Class69Service',
-            'dicontainerbenchmarks\\fixture\\class7' => 'getDicontainerbenchmarks_Fixture_Class7Service',
-            'dicontainerbenchmarks\\fixture\\class70' => 'getDicontainerbenchmarks_Fixture_Class70Service',
-            'dicontainerbenchmarks\\fixture\\class71' => 'getDicontainerbenchmarks_Fixture_Class71Service',
-            'dicontainerbenchmarks\\fixture\\class72' => 'getDicontainerbenchmarks_Fixture_Class72Service',
-            'dicontainerbenchmarks\\fixture\\class73' => 'getDicontainerbenchmarks_Fixture_Class73Service',
-            'dicontainerbenchmarks\\fixture\\class74' => 'getDicontainerbenchmarks_Fixture_Class74Service',
-            'dicontainerbenchmarks\\fixture\\class75' => 'getDicontainerbenchmarks_Fixture_Class75Service',
-            'dicontainerbenchmarks\\fixture\\class76' => 'getDicontainerbenchmarks_Fixture_Class76Service',
-            'dicontainerbenchmarks\\fixture\\class77' => 'getDicontainerbenchmarks_Fixture_Class77Service',
-            'dicontainerbenchmarks\\fixture\\class78' => 'getDicontainerbenchmarks_Fixture_Class78Service',
-            'dicontainerbenchmarks\\fixture\\class79' => 'getDicontainerbenchmarks_Fixture_Class79Service',
-            'dicontainerbenchmarks\\fixture\\class8' => 'getDicontainerbenchmarks_Fixture_Class8Service',
-            'dicontainerbenchmarks\\fixture\\class80' => 'getDicontainerbenchmarks_Fixture_Class80Service',
-            'dicontainerbenchmarks\\fixture\\class81' => 'getDicontainerbenchmarks_Fixture_Class81Service',
-            'dicontainerbenchmarks\\fixture\\class82' => 'getDicontainerbenchmarks_Fixture_Class82Service',
-            'dicontainerbenchmarks\\fixture\\class83' => 'getDicontainerbenchmarks_Fixture_Class83Service',
-            'dicontainerbenchmarks\\fixture\\class84' => 'getDicontainerbenchmarks_Fixture_Class84Service',
-            'dicontainerbenchmarks\\fixture\\class85' => 'getDicontainerbenchmarks_Fixture_Class85Service',
-            'dicontainerbenchmarks\\fixture\\class86' => 'getDicontainerbenchmarks_Fixture_Class86Service',
-            'dicontainerbenchmarks\\fixture\\class87' => 'getDicontainerbenchmarks_Fixture_Class87Service',
-            'dicontainerbenchmarks\\fixture\\class88' => 'getDicontainerbenchmarks_Fixture_Class88Service',
-            'dicontainerbenchmarks\\fixture\\class89' => 'getDicontainerbenchmarks_Fixture_Class89Service',
-            'dicontainerbenchmarks\\fixture\\class9' => 'getDicontainerbenchmarks_Fixture_Class9Service',
-            'dicontainerbenchmarks\\fixture\\class90' => 'getDicontainerbenchmarks_Fixture_Class90Service',
-            'dicontainerbenchmarks\\fixture\\class91' => 'getDicontainerbenchmarks_Fixture_Class91Service',
-            'dicontainerbenchmarks\\fixture\\class92' => 'getDicontainerbenchmarks_Fixture_Class92Service',
-            'dicontainerbenchmarks\\fixture\\class93' => 'getDicontainerbenchmarks_Fixture_Class93Service',
-            'dicontainerbenchmarks\\fixture\\class94' => 'getDicontainerbenchmarks_Fixture_Class94Service',
-            'dicontainerbenchmarks\\fixture\\class95' => 'getDicontainerbenchmarks_Fixture_Class95Service',
-            'dicontainerbenchmarks\\fixture\\class96' => 'getDicontainerbenchmarks_Fixture_Class96Service',
-            'dicontainerbenchmarks\\fixture\\class97' => 'getDicontainerbenchmarks_Fixture_Class97Service',
-            'dicontainerbenchmarks\\fixture\\class98' => 'getDicontainerbenchmarks_Fixture_Class98Service',
-            'dicontainerbenchmarks\\fixture\\class99' => 'getDicontainerbenchmarks_Fixture_Class99Service',
+            'class1' => 'getClass1Service',
+            'class10' => 'getClass10Service',
+            'class100' => 'getClass100Service',
+            'class11' => 'getClass11Service',
+            'class12' => 'getClass12Service',
+            'class13' => 'getClass13Service',
+            'class14' => 'getClass14Service',
+            'class15' => 'getClass15Service',
+            'class16' => 'getClass16Service',
+            'class17' => 'getClass17Service',
+            'class18' => 'getClass18Service',
+            'class19' => 'getClass19Service',
+            'class2' => 'getClass2Service',
+            'class20' => 'getClass20Service',
+            'class21' => 'getClass21Service',
+            'class22' => 'getClass22Service',
+            'class23' => 'getClass23Service',
+            'class24' => 'getClass24Service',
+            'class25' => 'getClass25Service',
+            'class26' => 'getClass26Service',
+            'class27' => 'getClass27Service',
+            'class28' => 'getClass28Service',
+            'class29' => 'getClass29Service',
+            'class3' => 'getClass3Service',
+            'class30' => 'getClass30Service',
+            'class31' => 'getClass31Service',
+            'class32' => 'getClass32Service',
+            'class33' => 'getClass33Service',
+            'class34' => 'getClass34Service',
+            'class35' => 'getClass35Service',
+            'class36' => 'getClass36Service',
+            'class37' => 'getClass37Service',
+            'class38' => 'getClass38Service',
+            'class39' => 'getClass39Service',
+            'class4' => 'getClass4Service',
+            'class40' => 'getClass40Service',
+            'class41' => 'getClass41Service',
+            'class42' => 'getClass42Service',
+            'class43' => 'getClass43Service',
+            'class44' => 'getClass44Service',
+            'class45' => 'getClass45Service',
+            'class46' => 'getClass46Service',
+            'class47' => 'getClass47Service',
+            'class48' => 'getClass48Service',
+            'class49' => 'getClass49Service',
+            'class5' => 'getClass5Service',
+            'class50' => 'getClass50Service',
+            'class51' => 'getClass51Service',
+            'class52' => 'getClass52Service',
+            'class53' => 'getClass53Service',
+            'class54' => 'getClass54Service',
+            'class55' => 'getClass55Service',
+            'class56' => 'getClass56Service',
+            'class57' => 'getClass57Service',
+            'class58' => 'getClass58Service',
+            'class59' => 'getClass59Service',
+            'class6' => 'getClass6Service',
+            'class60' => 'getClass60Service',
+            'class61' => 'getClass61Service',
+            'class62' => 'getClass62Service',
+            'class63' => 'getClass63Service',
+            'class64' => 'getClass64Service',
+            'class65' => 'getClass65Service',
+            'class66' => 'getClass66Service',
+            'class67' => 'getClass67Service',
+            'class68' => 'getClass68Service',
+            'class69' => 'getClass69Service',
+            'class7' => 'getClass7Service',
+            'class70' => 'getClass70Service',
+            'class71' => 'getClass71Service',
+            'class72' => 'getClass72Service',
+            'class73' => 'getClass73Service',
+            'class74' => 'getClass74Service',
+            'class75' => 'getClass75Service',
+            'class76' => 'getClass76Service',
+            'class77' => 'getClass77Service',
+            'class78' => 'getClass78Service',
+            'class79' => 'getClass79Service',
+            'class8' => 'getClass8Service',
+            'class80' => 'getClass80Service',
+            'class81' => 'getClass81Service',
+            'class82' => 'getClass82Service',
+            'class83' => 'getClass83Service',
+            'class84' => 'getClass84Service',
+            'class85' => 'getClass85Service',
+            'class86' => 'getClass86Service',
+            'class87' => 'getClass87Service',
+            'class88' => 'getClass88Service',
+            'class89' => 'getClass89Service',
+            'class9' => 'getClass9Service',
+            'class90' => 'getClass90Service',
+            'class91' => 'getClass91Service',
+            'class92' => 'getClass92Service',
+            'class93' => 'getClass93Service',
+            'class94' => 'getClass94Service',
+            'class95' => 'getClass95Service',
+            'class96' => 'getClass96Service',
+            'class97' => 'getClass97Service',
+            'class98' => 'getClass98Service',
+            'class99' => 'getClass99Service',
         );
 
         $this->aliases = array();
@@ -148,1202 +148,1202 @@ class CompiledSingletonContainer extends Container
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class1' service.
+     * Gets the 'class1' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class1 A DiContainerBenchmarks\Fixture\Class1 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class1Service()
+    protected function getClass1Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class1'] = new \DiContainerBenchmarks\Fixture\Class1();
+        return $this->services['class1'] = new \DiContainerBenchmarks\Fixture\Class1();
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class10' service.
+     * Gets the 'class10' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class10 A DiContainerBenchmarks\Fixture\Class10 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class10Service()
+    protected function getClass10Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class10'] = new \DiContainerBenchmarks\Fixture\Class10($this->get('dicontainerbenchmarks\fixture\class9'));
+        return $this->services['class10'] = new \DiContainerBenchmarks\Fixture\Class10($this->get('class9'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class100' service.
+     * Gets the 'class100' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class100 A DiContainerBenchmarks\Fixture\Class100 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class100Service()
+    protected function getClass100Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class100'] = new \DiContainerBenchmarks\Fixture\Class100($this->get('dicontainerbenchmarks\fixture\class99'));
+        return $this->services['class100'] = new \DiContainerBenchmarks\Fixture\Class100($this->get('class99'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class11' service.
+     * Gets the 'class11' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class11 A DiContainerBenchmarks\Fixture\Class11 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class11Service()
+    protected function getClass11Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class11'] = new \DiContainerBenchmarks\Fixture\Class11($this->get('dicontainerbenchmarks\fixture\class10'));
+        return $this->services['class11'] = new \DiContainerBenchmarks\Fixture\Class11($this->get('class10'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class12' service.
+     * Gets the 'class12' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class12 A DiContainerBenchmarks\Fixture\Class12 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class12Service()
+    protected function getClass12Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class12'] = new \DiContainerBenchmarks\Fixture\Class12($this->get('dicontainerbenchmarks\fixture\class11'));
+        return $this->services['class12'] = new \DiContainerBenchmarks\Fixture\Class12($this->get('class11'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class13' service.
+     * Gets the 'class13' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class13 A DiContainerBenchmarks\Fixture\Class13 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class13Service()
+    protected function getClass13Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class13'] = new \DiContainerBenchmarks\Fixture\Class13($this->get('dicontainerbenchmarks\fixture\class12'));
+        return $this->services['class13'] = new \DiContainerBenchmarks\Fixture\Class13($this->get('class12'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class14' service.
+     * Gets the 'class14' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class14 A DiContainerBenchmarks\Fixture\Class14 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class14Service()
+    protected function getClass14Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class14'] = new \DiContainerBenchmarks\Fixture\Class14($this->get('dicontainerbenchmarks\fixture\class13'));
+        return $this->services['class14'] = new \DiContainerBenchmarks\Fixture\Class14($this->get('class13'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class15' service.
+     * Gets the 'class15' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class15 A DiContainerBenchmarks\Fixture\Class15 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class15Service()
+    protected function getClass15Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class15'] = new \DiContainerBenchmarks\Fixture\Class15($this->get('dicontainerbenchmarks\fixture\class14'));
+        return $this->services['class15'] = new \DiContainerBenchmarks\Fixture\Class15($this->get('class14'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class16' service.
+     * Gets the 'class16' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class16 A DiContainerBenchmarks\Fixture\Class16 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class16Service()
+    protected function getClass16Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class16'] = new \DiContainerBenchmarks\Fixture\Class16($this->get('dicontainerbenchmarks\fixture\class15'));
+        return $this->services['class16'] = new \DiContainerBenchmarks\Fixture\Class16($this->get('class15'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class17' service.
+     * Gets the 'class17' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class17 A DiContainerBenchmarks\Fixture\Class17 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class17Service()
+    protected function getClass17Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class17'] = new \DiContainerBenchmarks\Fixture\Class17($this->get('dicontainerbenchmarks\fixture\class16'));
+        return $this->services['class17'] = new \DiContainerBenchmarks\Fixture\Class17($this->get('class16'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class18' service.
+     * Gets the 'class18' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class18 A DiContainerBenchmarks\Fixture\Class18 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class18Service()
+    protected function getClass18Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class18'] = new \DiContainerBenchmarks\Fixture\Class18($this->get('dicontainerbenchmarks\fixture\class17'));
+        return $this->services['class18'] = new \DiContainerBenchmarks\Fixture\Class18($this->get('class17'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class19' service.
+     * Gets the 'class19' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class19 A DiContainerBenchmarks\Fixture\Class19 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class19Service()
+    protected function getClass19Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class19'] = new \DiContainerBenchmarks\Fixture\Class19($this->get('dicontainerbenchmarks\fixture\class18'));
+        return $this->services['class19'] = new \DiContainerBenchmarks\Fixture\Class19($this->get('class18'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class2' service.
+     * Gets the 'class2' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class2 A DiContainerBenchmarks\Fixture\Class2 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class2Service()
+    protected function getClass2Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class2'] = new \DiContainerBenchmarks\Fixture\Class2($this->get('dicontainerbenchmarks\fixture\class1'));
+        return $this->services['class2'] = new \DiContainerBenchmarks\Fixture\Class2($this->get('class1'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class20' service.
+     * Gets the 'class20' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class20 A DiContainerBenchmarks\Fixture\Class20 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class20Service()
+    protected function getClass20Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class20'] = new \DiContainerBenchmarks\Fixture\Class20($this->get('dicontainerbenchmarks\fixture\class19'));
+        return $this->services['class20'] = new \DiContainerBenchmarks\Fixture\Class20($this->get('class19'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class21' service.
+     * Gets the 'class21' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class21 A DiContainerBenchmarks\Fixture\Class21 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class21Service()
+    protected function getClass21Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class21'] = new \DiContainerBenchmarks\Fixture\Class21($this->get('dicontainerbenchmarks\fixture\class20'));
+        return $this->services['class21'] = new \DiContainerBenchmarks\Fixture\Class21($this->get('class20'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class22' service.
+     * Gets the 'class22' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class22 A DiContainerBenchmarks\Fixture\Class22 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class22Service()
+    protected function getClass22Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class22'] = new \DiContainerBenchmarks\Fixture\Class22($this->get('dicontainerbenchmarks\fixture\class21'));
+        return $this->services['class22'] = new \DiContainerBenchmarks\Fixture\Class22($this->get('class21'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class23' service.
+     * Gets the 'class23' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class23 A DiContainerBenchmarks\Fixture\Class23 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class23Service()
+    protected function getClass23Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class23'] = new \DiContainerBenchmarks\Fixture\Class23($this->get('dicontainerbenchmarks\fixture\class22'));
+        return $this->services['class23'] = new \DiContainerBenchmarks\Fixture\Class23($this->get('class22'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class24' service.
+     * Gets the 'class24' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class24 A DiContainerBenchmarks\Fixture\Class24 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class24Service()
+    protected function getClass24Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class24'] = new \DiContainerBenchmarks\Fixture\Class24($this->get('dicontainerbenchmarks\fixture\class23'));
+        return $this->services['class24'] = new \DiContainerBenchmarks\Fixture\Class24($this->get('class23'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class25' service.
+     * Gets the 'class25' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class25 A DiContainerBenchmarks\Fixture\Class25 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class25Service()
+    protected function getClass25Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class25'] = new \DiContainerBenchmarks\Fixture\Class25($this->get('dicontainerbenchmarks\fixture\class24'));
+        return $this->services['class25'] = new \DiContainerBenchmarks\Fixture\Class25($this->get('class24'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class26' service.
+     * Gets the 'class26' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class26 A DiContainerBenchmarks\Fixture\Class26 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class26Service()
+    protected function getClass26Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class26'] = new \DiContainerBenchmarks\Fixture\Class26($this->get('dicontainerbenchmarks\fixture\class25'));
+        return $this->services['class26'] = new \DiContainerBenchmarks\Fixture\Class26($this->get('class25'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class27' service.
+     * Gets the 'class27' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class27 A DiContainerBenchmarks\Fixture\Class27 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class27Service()
+    protected function getClass27Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class27'] = new \DiContainerBenchmarks\Fixture\Class27($this->get('dicontainerbenchmarks\fixture\class26'));
+        return $this->services['class27'] = new \DiContainerBenchmarks\Fixture\Class27($this->get('class26'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class28' service.
+     * Gets the 'class28' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class28 A DiContainerBenchmarks\Fixture\Class28 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class28Service()
+    protected function getClass28Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class28'] = new \DiContainerBenchmarks\Fixture\Class28($this->get('dicontainerbenchmarks\fixture\class27'));
+        return $this->services['class28'] = new \DiContainerBenchmarks\Fixture\Class28($this->get('class27'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class29' service.
+     * Gets the 'class29' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class29 A DiContainerBenchmarks\Fixture\Class29 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class29Service()
+    protected function getClass29Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class29'] = new \DiContainerBenchmarks\Fixture\Class29($this->get('dicontainerbenchmarks\fixture\class28'));
+        return $this->services['class29'] = new \DiContainerBenchmarks\Fixture\Class29($this->get('class28'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class3' service.
+     * Gets the 'class3' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class3 A DiContainerBenchmarks\Fixture\Class3 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class3Service()
+    protected function getClass3Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class3'] = new \DiContainerBenchmarks\Fixture\Class3($this->get('dicontainerbenchmarks\fixture\class2'));
+        return $this->services['class3'] = new \DiContainerBenchmarks\Fixture\Class3($this->get('class2'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class30' service.
+     * Gets the 'class30' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class30 A DiContainerBenchmarks\Fixture\Class30 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class30Service()
+    protected function getClass30Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class30'] = new \DiContainerBenchmarks\Fixture\Class30($this->get('dicontainerbenchmarks\fixture\class29'));
+        return $this->services['class30'] = new \DiContainerBenchmarks\Fixture\Class30($this->get('class29'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class31' service.
+     * Gets the 'class31' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class31 A DiContainerBenchmarks\Fixture\Class31 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class31Service()
+    protected function getClass31Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class31'] = new \DiContainerBenchmarks\Fixture\Class31($this->get('dicontainerbenchmarks\fixture\class30'));
+        return $this->services['class31'] = new \DiContainerBenchmarks\Fixture\Class31($this->get('class30'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class32' service.
+     * Gets the 'class32' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class32 A DiContainerBenchmarks\Fixture\Class32 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class32Service()
+    protected function getClass32Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class32'] = new \DiContainerBenchmarks\Fixture\Class32($this->get('dicontainerbenchmarks\fixture\class31'));
+        return $this->services['class32'] = new \DiContainerBenchmarks\Fixture\Class32($this->get('class31'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class33' service.
+     * Gets the 'class33' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class33 A DiContainerBenchmarks\Fixture\Class33 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class33Service()
+    protected function getClass33Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class33'] = new \DiContainerBenchmarks\Fixture\Class33($this->get('dicontainerbenchmarks\fixture\class32'));
+        return $this->services['class33'] = new \DiContainerBenchmarks\Fixture\Class33($this->get('class32'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class34' service.
+     * Gets the 'class34' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class34 A DiContainerBenchmarks\Fixture\Class34 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class34Service()
+    protected function getClass34Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class34'] = new \DiContainerBenchmarks\Fixture\Class34($this->get('dicontainerbenchmarks\fixture\class33'));
+        return $this->services['class34'] = new \DiContainerBenchmarks\Fixture\Class34($this->get('class33'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class35' service.
+     * Gets the 'class35' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class35 A DiContainerBenchmarks\Fixture\Class35 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class35Service()
+    protected function getClass35Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class35'] = new \DiContainerBenchmarks\Fixture\Class35($this->get('dicontainerbenchmarks\fixture\class34'));
+        return $this->services['class35'] = new \DiContainerBenchmarks\Fixture\Class35($this->get('class34'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class36' service.
+     * Gets the 'class36' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class36 A DiContainerBenchmarks\Fixture\Class36 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class36Service()
+    protected function getClass36Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class36'] = new \DiContainerBenchmarks\Fixture\Class36($this->get('dicontainerbenchmarks\fixture\class35'));
+        return $this->services['class36'] = new \DiContainerBenchmarks\Fixture\Class36($this->get('class35'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class37' service.
+     * Gets the 'class37' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class37 A DiContainerBenchmarks\Fixture\Class37 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class37Service()
+    protected function getClass37Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class37'] = new \DiContainerBenchmarks\Fixture\Class37($this->get('dicontainerbenchmarks\fixture\class36'));
+        return $this->services['class37'] = new \DiContainerBenchmarks\Fixture\Class37($this->get('class36'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class38' service.
+     * Gets the 'class38' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class38 A DiContainerBenchmarks\Fixture\Class38 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class38Service()
+    protected function getClass38Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class38'] = new \DiContainerBenchmarks\Fixture\Class38($this->get('dicontainerbenchmarks\fixture\class37'));
+        return $this->services['class38'] = new \DiContainerBenchmarks\Fixture\Class38($this->get('class37'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class39' service.
+     * Gets the 'class39' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class39 A DiContainerBenchmarks\Fixture\Class39 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class39Service()
+    protected function getClass39Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class39'] = new \DiContainerBenchmarks\Fixture\Class39($this->get('dicontainerbenchmarks\fixture\class38'));
+        return $this->services['class39'] = new \DiContainerBenchmarks\Fixture\Class39($this->get('class38'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class4' service.
+     * Gets the 'class4' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class4 A DiContainerBenchmarks\Fixture\Class4 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class4Service()
+    protected function getClass4Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class4'] = new \DiContainerBenchmarks\Fixture\Class4($this->get('dicontainerbenchmarks\fixture\class3'));
+        return $this->services['class4'] = new \DiContainerBenchmarks\Fixture\Class4($this->get('class3'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class40' service.
+     * Gets the 'class40' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class40 A DiContainerBenchmarks\Fixture\Class40 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class40Service()
+    protected function getClass40Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class40'] = new \DiContainerBenchmarks\Fixture\Class40($this->get('dicontainerbenchmarks\fixture\class39'));
+        return $this->services['class40'] = new \DiContainerBenchmarks\Fixture\Class40($this->get('class39'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class41' service.
+     * Gets the 'class41' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class41 A DiContainerBenchmarks\Fixture\Class41 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class41Service()
+    protected function getClass41Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class41'] = new \DiContainerBenchmarks\Fixture\Class41($this->get('dicontainerbenchmarks\fixture\class40'));
+        return $this->services['class41'] = new \DiContainerBenchmarks\Fixture\Class41($this->get('class40'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class42' service.
+     * Gets the 'class42' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class42 A DiContainerBenchmarks\Fixture\Class42 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class42Service()
+    protected function getClass42Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class42'] = new \DiContainerBenchmarks\Fixture\Class42($this->get('dicontainerbenchmarks\fixture\class41'));
+        return $this->services['class42'] = new \DiContainerBenchmarks\Fixture\Class42($this->get('class41'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class43' service.
+     * Gets the 'class43' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class43 A DiContainerBenchmarks\Fixture\Class43 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class43Service()
+    protected function getClass43Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class43'] = new \DiContainerBenchmarks\Fixture\Class43($this->get('dicontainerbenchmarks\fixture\class42'));
+        return $this->services['class43'] = new \DiContainerBenchmarks\Fixture\Class43($this->get('class42'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class44' service.
+     * Gets the 'class44' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class44 A DiContainerBenchmarks\Fixture\Class44 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class44Service()
+    protected function getClass44Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class44'] = new \DiContainerBenchmarks\Fixture\Class44($this->get('dicontainerbenchmarks\fixture\class43'));
+        return $this->services['class44'] = new \DiContainerBenchmarks\Fixture\Class44($this->get('class43'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class45' service.
+     * Gets the 'class45' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class45 A DiContainerBenchmarks\Fixture\Class45 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class45Service()
+    protected function getClass45Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class45'] = new \DiContainerBenchmarks\Fixture\Class45($this->get('dicontainerbenchmarks\fixture\class44'));
+        return $this->services['class45'] = new \DiContainerBenchmarks\Fixture\Class45($this->get('class44'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class46' service.
+     * Gets the 'class46' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class46 A DiContainerBenchmarks\Fixture\Class46 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class46Service()
+    protected function getClass46Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class46'] = new \DiContainerBenchmarks\Fixture\Class46($this->get('dicontainerbenchmarks\fixture\class45'));
+        return $this->services['class46'] = new \DiContainerBenchmarks\Fixture\Class46($this->get('class45'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class47' service.
+     * Gets the 'class47' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class47 A DiContainerBenchmarks\Fixture\Class47 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class47Service()
+    protected function getClass47Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class47'] = new \DiContainerBenchmarks\Fixture\Class47($this->get('dicontainerbenchmarks\fixture\class46'));
+        return $this->services['class47'] = new \DiContainerBenchmarks\Fixture\Class47($this->get('class46'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class48' service.
+     * Gets the 'class48' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class48 A DiContainerBenchmarks\Fixture\Class48 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class48Service()
+    protected function getClass48Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class48'] = new \DiContainerBenchmarks\Fixture\Class48($this->get('dicontainerbenchmarks\fixture\class47'));
+        return $this->services['class48'] = new \DiContainerBenchmarks\Fixture\Class48($this->get('class47'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class49' service.
+     * Gets the 'class49' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class49 A DiContainerBenchmarks\Fixture\Class49 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class49Service()
+    protected function getClass49Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class49'] = new \DiContainerBenchmarks\Fixture\Class49($this->get('dicontainerbenchmarks\fixture\class48'));
+        return $this->services['class49'] = new \DiContainerBenchmarks\Fixture\Class49($this->get('class48'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class5' service.
+     * Gets the 'class5' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class5 A DiContainerBenchmarks\Fixture\Class5 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class5Service()
+    protected function getClass5Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class5'] = new \DiContainerBenchmarks\Fixture\Class5($this->get('dicontainerbenchmarks\fixture\class4'));
+        return $this->services['class5'] = new \DiContainerBenchmarks\Fixture\Class5($this->get('class4'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class50' service.
+     * Gets the 'class50' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class50 A DiContainerBenchmarks\Fixture\Class50 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class50Service()
+    protected function getClass50Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class50'] = new \DiContainerBenchmarks\Fixture\Class50($this->get('dicontainerbenchmarks\fixture\class49'));
+        return $this->services['class50'] = new \DiContainerBenchmarks\Fixture\Class50($this->get('class49'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class51' service.
+     * Gets the 'class51' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class51 A DiContainerBenchmarks\Fixture\Class51 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class51Service()
+    protected function getClass51Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class51'] = new \DiContainerBenchmarks\Fixture\Class51($this->get('dicontainerbenchmarks\fixture\class50'));
+        return $this->services['class51'] = new \DiContainerBenchmarks\Fixture\Class51($this->get('class50'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class52' service.
+     * Gets the 'class52' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class52 A DiContainerBenchmarks\Fixture\Class52 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class52Service()
+    protected function getClass52Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class52'] = new \DiContainerBenchmarks\Fixture\Class52($this->get('dicontainerbenchmarks\fixture\class51'));
+        return $this->services['class52'] = new \DiContainerBenchmarks\Fixture\Class52($this->get('class51'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class53' service.
+     * Gets the 'class53' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class53 A DiContainerBenchmarks\Fixture\Class53 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class53Service()
+    protected function getClass53Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class53'] = new \DiContainerBenchmarks\Fixture\Class53($this->get('dicontainerbenchmarks\fixture\class52'));
+        return $this->services['class53'] = new \DiContainerBenchmarks\Fixture\Class53($this->get('class52'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class54' service.
+     * Gets the 'class54' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class54 A DiContainerBenchmarks\Fixture\Class54 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class54Service()
+    protected function getClass54Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class54'] = new \DiContainerBenchmarks\Fixture\Class54($this->get('dicontainerbenchmarks\fixture\class53'));
+        return $this->services['class54'] = new \DiContainerBenchmarks\Fixture\Class54($this->get('class53'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class55' service.
+     * Gets the 'class55' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class55 A DiContainerBenchmarks\Fixture\Class55 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class55Service()
+    protected function getClass55Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class55'] = new \DiContainerBenchmarks\Fixture\Class55($this->get('dicontainerbenchmarks\fixture\class54'));
+        return $this->services['class55'] = new \DiContainerBenchmarks\Fixture\Class55($this->get('class54'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class56' service.
+     * Gets the 'class56' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class56 A DiContainerBenchmarks\Fixture\Class56 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class56Service()
+    protected function getClass56Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class56'] = new \DiContainerBenchmarks\Fixture\Class56($this->get('dicontainerbenchmarks\fixture\class55'));
+        return $this->services['class56'] = new \DiContainerBenchmarks\Fixture\Class56($this->get('class55'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class57' service.
+     * Gets the 'class57' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class57 A DiContainerBenchmarks\Fixture\Class57 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class57Service()
+    protected function getClass57Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class57'] = new \DiContainerBenchmarks\Fixture\Class57($this->get('dicontainerbenchmarks\fixture\class56'));
+        return $this->services['class57'] = new \DiContainerBenchmarks\Fixture\Class57($this->get('class56'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class58' service.
+     * Gets the 'class58' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class58 A DiContainerBenchmarks\Fixture\Class58 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class58Service()
+    protected function getClass58Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class58'] = new \DiContainerBenchmarks\Fixture\Class58($this->get('dicontainerbenchmarks\fixture\class57'));
+        return $this->services['class58'] = new \DiContainerBenchmarks\Fixture\Class58($this->get('class57'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class59' service.
+     * Gets the 'class59' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class59 A DiContainerBenchmarks\Fixture\Class59 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class59Service()
+    protected function getClass59Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class59'] = new \DiContainerBenchmarks\Fixture\Class59($this->get('dicontainerbenchmarks\fixture\class58'));
+        return $this->services['class59'] = new \DiContainerBenchmarks\Fixture\Class59($this->get('class58'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class6' service.
+     * Gets the 'class6' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class6 A DiContainerBenchmarks\Fixture\Class6 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class6Service()
+    protected function getClass6Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class6'] = new \DiContainerBenchmarks\Fixture\Class6($this->get('dicontainerbenchmarks\fixture\class5'));
+        return $this->services['class6'] = new \DiContainerBenchmarks\Fixture\Class6($this->get('class5'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class60' service.
+     * Gets the 'class60' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class60 A DiContainerBenchmarks\Fixture\Class60 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class60Service()
+    protected function getClass60Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class60'] = new \DiContainerBenchmarks\Fixture\Class60($this->get('dicontainerbenchmarks\fixture\class59'));
+        return $this->services['class60'] = new \DiContainerBenchmarks\Fixture\Class60($this->get('class59'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class61' service.
+     * Gets the 'class61' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class61 A DiContainerBenchmarks\Fixture\Class61 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class61Service()
+    protected function getClass61Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class61'] = new \DiContainerBenchmarks\Fixture\Class61($this->get('dicontainerbenchmarks\fixture\class60'));
+        return $this->services['class61'] = new \DiContainerBenchmarks\Fixture\Class61($this->get('class60'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class62' service.
+     * Gets the 'class62' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class62 A DiContainerBenchmarks\Fixture\Class62 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class62Service()
+    protected function getClass62Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class62'] = new \DiContainerBenchmarks\Fixture\Class62($this->get('dicontainerbenchmarks\fixture\class61'));
+        return $this->services['class62'] = new \DiContainerBenchmarks\Fixture\Class62($this->get('class61'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class63' service.
+     * Gets the 'class63' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class63 A DiContainerBenchmarks\Fixture\Class63 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class63Service()
+    protected function getClass63Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class63'] = new \DiContainerBenchmarks\Fixture\Class63($this->get('dicontainerbenchmarks\fixture\class62'));
+        return $this->services['class63'] = new \DiContainerBenchmarks\Fixture\Class63($this->get('class62'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class64' service.
+     * Gets the 'class64' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class64 A DiContainerBenchmarks\Fixture\Class64 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class64Service()
+    protected function getClass64Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class64'] = new \DiContainerBenchmarks\Fixture\Class64($this->get('dicontainerbenchmarks\fixture\class63'));
+        return $this->services['class64'] = new \DiContainerBenchmarks\Fixture\Class64($this->get('class63'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class65' service.
+     * Gets the 'class65' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class65 A DiContainerBenchmarks\Fixture\Class65 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class65Service()
+    protected function getClass65Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class65'] = new \DiContainerBenchmarks\Fixture\Class65($this->get('dicontainerbenchmarks\fixture\class64'));
+        return $this->services['class65'] = new \DiContainerBenchmarks\Fixture\Class65($this->get('class64'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class66' service.
+     * Gets the 'class66' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class66 A DiContainerBenchmarks\Fixture\Class66 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class66Service()
+    protected function getClass66Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class66'] = new \DiContainerBenchmarks\Fixture\Class66($this->get('dicontainerbenchmarks\fixture\class65'));
+        return $this->services['class66'] = new \DiContainerBenchmarks\Fixture\Class66($this->get('class65'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class67' service.
+     * Gets the 'class67' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class67 A DiContainerBenchmarks\Fixture\Class67 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class67Service()
+    protected function getClass67Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class67'] = new \DiContainerBenchmarks\Fixture\Class67($this->get('dicontainerbenchmarks\fixture\class66'));
+        return $this->services['class67'] = new \DiContainerBenchmarks\Fixture\Class67($this->get('class66'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class68' service.
+     * Gets the 'class68' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class68 A DiContainerBenchmarks\Fixture\Class68 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class68Service()
+    protected function getClass68Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class68'] = new \DiContainerBenchmarks\Fixture\Class68($this->get('dicontainerbenchmarks\fixture\class67'));
+        return $this->services['class68'] = new \DiContainerBenchmarks\Fixture\Class68($this->get('class67'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class69' service.
+     * Gets the 'class69' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class69 A DiContainerBenchmarks\Fixture\Class69 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class69Service()
+    protected function getClass69Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class69'] = new \DiContainerBenchmarks\Fixture\Class69($this->get('dicontainerbenchmarks\fixture\class68'));
+        return $this->services['class69'] = new \DiContainerBenchmarks\Fixture\Class69($this->get('class68'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class7' service.
+     * Gets the 'class7' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class7 A DiContainerBenchmarks\Fixture\Class7 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class7Service()
+    protected function getClass7Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class7'] = new \DiContainerBenchmarks\Fixture\Class7($this->get('dicontainerbenchmarks\fixture\class6'));
+        return $this->services['class7'] = new \DiContainerBenchmarks\Fixture\Class7($this->get('class6'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class70' service.
+     * Gets the 'class70' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class70 A DiContainerBenchmarks\Fixture\Class70 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class70Service()
+    protected function getClass70Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class70'] = new \DiContainerBenchmarks\Fixture\Class70($this->get('dicontainerbenchmarks\fixture\class69'));
+        return $this->services['class70'] = new \DiContainerBenchmarks\Fixture\Class70($this->get('class69'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class71' service.
+     * Gets the 'class71' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class71 A DiContainerBenchmarks\Fixture\Class71 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class71Service()
+    protected function getClass71Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class71'] = new \DiContainerBenchmarks\Fixture\Class71($this->get('dicontainerbenchmarks\fixture\class70'));
+        return $this->services['class71'] = new \DiContainerBenchmarks\Fixture\Class71($this->get('class70'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class72' service.
+     * Gets the 'class72' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class72 A DiContainerBenchmarks\Fixture\Class72 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class72Service()
+    protected function getClass72Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class72'] = new \DiContainerBenchmarks\Fixture\Class72($this->get('dicontainerbenchmarks\fixture\class71'));
+        return $this->services['class72'] = new \DiContainerBenchmarks\Fixture\Class72($this->get('class71'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class73' service.
+     * Gets the 'class73' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class73 A DiContainerBenchmarks\Fixture\Class73 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class73Service()
+    protected function getClass73Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class73'] = new \DiContainerBenchmarks\Fixture\Class73($this->get('dicontainerbenchmarks\fixture\class72'));
+        return $this->services['class73'] = new \DiContainerBenchmarks\Fixture\Class73($this->get('class72'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class74' service.
+     * Gets the 'class74' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class74 A DiContainerBenchmarks\Fixture\Class74 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class74Service()
+    protected function getClass74Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class74'] = new \DiContainerBenchmarks\Fixture\Class74($this->get('dicontainerbenchmarks\fixture\class73'));
+        return $this->services['class74'] = new \DiContainerBenchmarks\Fixture\Class74($this->get('class73'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class75' service.
+     * Gets the 'class75' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class75 A DiContainerBenchmarks\Fixture\Class75 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class75Service()
+    protected function getClass75Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class75'] = new \DiContainerBenchmarks\Fixture\Class75($this->get('dicontainerbenchmarks\fixture\class74'));
+        return $this->services['class75'] = new \DiContainerBenchmarks\Fixture\Class75($this->get('class74'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class76' service.
+     * Gets the 'class76' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class76 A DiContainerBenchmarks\Fixture\Class76 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class76Service()
+    protected function getClass76Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class76'] = new \DiContainerBenchmarks\Fixture\Class76($this->get('dicontainerbenchmarks\fixture\class75'));
+        return $this->services['class76'] = new \DiContainerBenchmarks\Fixture\Class76($this->get('class75'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class77' service.
+     * Gets the 'class77' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class77 A DiContainerBenchmarks\Fixture\Class77 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class77Service()
+    protected function getClass77Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class77'] = new \DiContainerBenchmarks\Fixture\Class77($this->get('dicontainerbenchmarks\fixture\class76'));
+        return $this->services['class77'] = new \DiContainerBenchmarks\Fixture\Class77($this->get('class76'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class78' service.
+     * Gets the 'class78' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class78 A DiContainerBenchmarks\Fixture\Class78 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class78Service()
+    protected function getClass78Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class78'] = new \DiContainerBenchmarks\Fixture\Class78($this->get('dicontainerbenchmarks\fixture\class77'));
+        return $this->services['class78'] = new \DiContainerBenchmarks\Fixture\Class78($this->get('class77'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class79' service.
+     * Gets the 'class79' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class79 A DiContainerBenchmarks\Fixture\Class79 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class79Service()
+    protected function getClass79Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class79'] = new \DiContainerBenchmarks\Fixture\Class79($this->get('dicontainerbenchmarks\fixture\class78'));
+        return $this->services['class79'] = new \DiContainerBenchmarks\Fixture\Class79($this->get('class78'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class8' service.
+     * Gets the 'class8' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class8 A DiContainerBenchmarks\Fixture\Class8 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class8Service()
+    protected function getClass8Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class8'] = new \DiContainerBenchmarks\Fixture\Class8($this->get('dicontainerbenchmarks\fixture\class7'));
+        return $this->services['class8'] = new \DiContainerBenchmarks\Fixture\Class8($this->get('class7'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class80' service.
+     * Gets the 'class80' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class80 A DiContainerBenchmarks\Fixture\Class80 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class80Service()
+    protected function getClass80Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class80'] = new \DiContainerBenchmarks\Fixture\Class80($this->get('dicontainerbenchmarks\fixture\class79'));
+        return $this->services['class80'] = new \DiContainerBenchmarks\Fixture\Class80($this->get('class79'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class81' service.
+     * Gets the 'class81' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class81 A DiContainerBenchmarks\Fixture\Class81 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class81Service()
+    protected function getClass81Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class81'] = new \DiContainerBenchmarks\Fixture\Class81($this->get('dicontainerbenchmarks\fixture\class80'));
+        return $this->services['class81'] = new \DiContainerBenchmarks\Fixture\Class81($this->get('class80'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class82' service.
+     * Gets the 'class82' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class82 A DiContainerBenchmarks\Fixture\Class82 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class82Service()
+    protected function getClass82Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class82'] = new \DiContainerBenchmarks\Fixture\Class82($this->get('dicontainerbenchmarks\fixture\class81'));
+        return $this->services['class82'] = new \DiContainerBenchmarks\Fixture\Class82($this->get('class81'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class83' service.
+     * Gets the 'class83' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class83 A DiContainerBenchmarks\Fixture\Class83 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class83Service()
+    protected function getClass83Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class83'] = new \DiContainerBenchmarks\Fixture\Class83($this->get('dicontainerbenchmarks\fixture\class82'));
+        return $this->services['class83'] = new \DiContainerBenchmarks\Fixture\Class83($this->get('class82'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class84' service.
+     * Gets the 'class84' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class84 A DiContainerBenchmarks\Fixture\Class84 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class84Service()
+    protected function getClass84Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class84'] = new \DiContainerBenchmarks\Fixture\Class84($this->get('dicontainerbenchmarks\fixture\class83'));
+        return $this->services['class84'] = new \DiContainerBenchmarks\Fixture\Class84($this->get('class83'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class85' service.
+     * Gets the 'class85' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class85 A DiContainerBenchmarks\Fixture\Class85 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class85Service()
+    protected function getClass85Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class85'] = new \DiContainerBenchmarks\Fixture\Class85($this->get('dicontainerbenchmarks\fixture\class84'));
+        return $this->services['class85'] = new \DiContainerBenchmarks\Fixture\Class85($this->get('class84'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class86' service.
+     * Gets the 'class86' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class86 A DiContainerBenchmarks\Fixture\Class86 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class86Service()
+    protected function getClass86Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class86'] = new \DiContainerBenchmarks\Fixture\Class86($this->get('dicontainerbenchmarks\fixture\class85'));
+        return $this->services['class86'] = new \DiContainerBenchmarks\Fixture\Class86($this->get('class85'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class87' service.
+     * Gets the 'class87' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class87 A DiContainerBenchmarks\Fixture\Class87 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class87Service()
+    protected function getClass87Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class87'] = new \DiContainerBenchmarks\Fixture\Class87($this->get('dicontainerbenchmarks\fixture\class86'));
+        return $this->services['class87'] = new \DiContainerBenchmarks\Fixture\Class87($this->get('class86'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class88' service.
+     * Gets the 'class88' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class88 A DiContainerBenchmarks\Fixture\Class88 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class88Service()
+    protected function getClass88Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class88'] = new \DiContainerBenchmarks\Fixture\Class88($this->get('dicontainerbenchmarks\fixture\class87'));
+        return $this->services['class88'] = new \DiContainerBenchmarks\Fixture\Class88($this->get('class87'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class89' service.
+     * Gets the 'class89' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class89 A DiContainerBenchmarks\Fixture\Class89 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class89Service()
+    protected function getClass89Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class89'] = new \DiContainerBenchmarks\Fixture\Class89($this->get('dicontainerbenchmarks\fixture\class88'));
+        return $this->services['class89'] = new \DiContainerBenchmarks\Fixture\Class89($this->get('class88'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class9' service.
+     * Gets the 'class9' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class9 A DiContainerBenchmarks\Fixture\Class9 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class9Service()
+    protected function getClass9Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class9'] = new \DiContainerBenchmarks\Fixture\Class9($this->get('dicontainerbenchmarks\fixture\class8'));
+        return $this->services['class9'] = new \DiContainerBenchmarks\Fixture\Class9($this->get('class8'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class90' service.
+     * Gets the 'class90' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class90 A DiContainerBenchmarks\Fixture\Class90 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class90Service()
+    protected function getClass90Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class90'] = new \DiContainerBenchmarks\Fixture\Class90($this->get('dicontainerbenchmarks\fixture\class89'));
+        return $this->services['class90'] = new \DiContainerBenchmarks\Fixture\Class90($this->get('class89'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class91' service.
+     * Gets the 'class91' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class91 A DiContainerBenchmarks\Fixture\Class91 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class91Service()
+    protected function getClass91Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class91'] = new \DiContainerBenchmarks\Fixture\Class91($this->get('dicontainerbenchmarks\fixture\class90'));
+        return $this->services['class91'] = new \DiContainerBenchmarks\Fixture\Class91($this->get('class90'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class92' service.
+     * Gets the 'class92' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class92 A DiContainerBenchmarks\Fixture\Class92 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class92Service()
+    protected function getClass92Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class92'] = new \DiContainerBenchmarks\Fixture\Class92($this->get('dicontainerbenchmarks\fixture\class91'));
+        return $this->services['class92'] = new \DiContainerBenchmarks\Fixture\Class92($this->get('class91'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class93' service.
+     * Gets the 'class93' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class93 A DiContainerBenchmarks\Fixture\Class93 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class93Service()
+    protected function getClass93Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class93'] = new \DiContainerBenchmarks\Fixture\Class93($this->get('dicontainerbenchmarks\fixture\class92'));
+        return $this->services['class93'] = new \DiContainerBenchmarks\Fixture\Class93($this->get('class92'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class94' service.
+     * Gets the 'class94' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class94 A DiContainerBenchmarks\Fixture\Class94 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class94Service()
+    protected function getClass94Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class94'] = new \DiContainerBenchmarks\Fixture\Class94($this->get('dicontainerbenchmarks\fixture\class93'));
+        return $this->services['class94'] = new \DiContainerBenchmarks\Fixture\Class94($this->get('class93'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class95' service.
+     * Gets the 'class95' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class95 A DiContainerBenchmarks\Fixture\Class95 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class95Service()
+    protected function getClass95Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class95'] = new \DiContainerBenchmarks\Fixture\Class95($this->get('dicontainerbenchmarks\fixture\class94'));
+        return $this->services['class95'] = new \DiContainerBenchmarks\Fixture\Class95($this->get('class94'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class96' service.
+     * Gets the 'class96' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class96 A DiContainerBenchmarks\Fixture\Class96 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class96Service()
+    protected function getClass96Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class96'] = new \DiContainerBenchmarks\Fixture\Class96($this->get('dicontainerbenchmarks\fixture\class95'));
+        return $this->services['class96'] = new \DiContainerBenchmarks\Fixture\Class96($this->get('class95'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class97' service.
+     * Gets the 'class97' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class97 A DiContainerBenchmarks\Fixture\Class97 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class97Service()
+    protected function getClass97Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class97'] = new \DiContainerBenchmarks\Fixture\Class97($this->get('dicontainerbenchmarks\fixture\class96'));
+        return $this->services['class97'] = new \DiContainerBenchmarks\Fixture\Class97($this->get('class96'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class98' service.
+     * Gets the 'class98' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class98 A DiContainerBenchmarks\Fixture\Class98 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class98Service()
+    protected function getClass98Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class98'] = new \DiContainerBenchmarks\Fixture\Class98($this->get('dicontainerbenchmarks\fixture\class97'));
+        return $this->services['class98'] = new \DiContainerBenchmarks\Fixture\Class98($this->get('class97'));
     }
 
     /*
-     * Gets the 'dicontainerbenchmarks\fixture\class99' service.
+     * Gets the 'class99' service.
      *
      * This service is autowired.
      *
      * @return \DiContainerBenchmarks\Fixture\Class99 A DiContainerBenchmarks\Fixture\Class99 instance
      */
-    protected function getDicontainerbenchmarks_Fixture_Class99Service()
+    protected function getClass99Service()
     {
-        return $this->services['dicontainerbenchmarks\fixture\class99'] = new \DiContainerBenchmarks\Fixture\Class99($this->get('dicontainerbenchmarks\fixture\class98'));
+        return $this->services['class99'] = new \DiContainerBenchmarks\Fixture\Class99($this->get('class98'));
     }
 }

--- a/src/Container/Symfony/SymfonyContainer.php
+++ b/src/Container/Symfony/SymfonyContainer.php
@@ -36,10 +36,10 @@ class SymfonyContainer implements ContainerInterface
         $containerBuilder = new ContainerBuilder();
 
         for ($i = 1; $i <= 100; $i++) {
-            $definition = new Definition('DiContainerBenchmarks\Fixture\Class' . $i, []);
+            $definition = new Definition("DiContainerBenchmarks\\Fixture\\Class$i", []);
             $definition->setShared(false);
             $definition->setAutowired(true);
-            $containerBuilder->setDefinition('DiContainerBenchmarks\Fixture\Class' . $i, $definition);
+            $containerBuilder->setDefinition("class$i", $definition);
         }
 
         $containerBuilder->compile();
@@ -60,10 +60,10 @@ class SymfonyContainer implements ContainerInterface
         $containerBuilder = new ContainerBuilder();
 
         for ($i = 1; $i <= 100; $i++) {
-            $definition = new Definition('DiContainerBenchmarks\Fixture\Class' . $i, []);
+            $definition = new Definition("DiContainerBenchmarks\\Fixture\\Class$i", []);
             $definition->setShared(true);
             $definition->setAutowired(true);
-            $containerBuilder->setDefinition('DiContainerBenchmarks\Fixture\Class' . $i, $definition);
+            $containerBuilder->setDefinition("class$i", $definition);
         }
 
         $containerBuilder->compile();

--- a/src/Container/Symfony/Test1.php
+++ b/src/Container/Symfony/Test1.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace DiContainerBenchmarks\Container\Symfony;
 
-use DiContainerBenchmarks\Fixture\Class10;
-
 class Test1 extends AbstractSymfonyTest
 {
     public function startup(): void
@@ -14,6 +12,6 @@ class Test1 extends AbstractSymfonyTest
 
     public function run(): void
     {
-        $this->container->get(Class10::class);
+        $this->container->get('class10');
     }
 }

--- a/src/Container/Symfony/Test2.php
+++ b/src/Container/Symfony/Test2.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace DiContainerBenchmarks\Container\Symfony;
 
-use DiContainerBenchmarks\Fixture\Class100;
-
 class Test2 extends AbstractSymfonyTest
 {
     public function startup(): void
@@ -14,6 +12,6 @@ class Test2 extends AbstractSymfonyTest
 
     public function run(): void
     {
-        $this->container->get(Class100::class);
+        $this->container->get('class100');
     }
 }

--- a/src/Container/Symfony/Test3.php
+++ b/src/Container/Symfony/Test3.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace DiContainerBenchmarks\Container\Symfony;
 
-use DiContainerBenchmarks\Fixture\Class10;
-
 class Test3 extends AbstractSymfonyTest
 {
     public function startup(): void
@@ -14,6 +12,6 @@ class Test3 extends AbstractSymfonyTest
 
     public function run(): void
     {
-        $this->container->get(Class10::class);
+        $this->container->get('class10');
     }
 }

--- a/src/Container/Symfony/Test4.php
+++ b/src/Container/Symfony/Test4.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace DiContainerBenchmarks\Container\Symfony;
 
-use DiContainerBenchmarks\Fixture\Class100;
-
 class Test4 extends AbstractSymfonyTest
 {
     public function startup(): void
@@ -14,6 +12,6 @@ class Test4 extends AbstractSymfonyTest
 
     public function run(): void
     {
-        $this->container->get(Class100::class);
+        $this->container->get('class100');
     }
 }

--- a/var/benchmark.html
+++ b/var/benchmark.html
@@ -21,7 +21,7 @@
                 <td><b>Repository:</b></td><td><a target="_blank" href="https://github.com/kocsismate/php-di-container-benchmarks">https://github.com/kocsismate/php-di-container-benchmarks</a></td>
             </tr>
             <tr>
-                <td><b>Generated:</b></td><td>2017-01-07 11:28:31</td>
+                <td><b>Generated:</b></td><td>2017-01-07 11:13:34</td>
             </tr>
         </table>
 
@@ -257,91 +257,91 @@
             </thead>
             <tbody>                <tr>
                     <th>1</th>
-                    <td><b>Symfony</b></td>
-                    <td>0.184</td> 
+                    <td><b>Zen</b></td>
+                    <td>0.202</td> 
                     <td>100%</td> 
-                    <td>2.56815</td> 
+                    <td>0.93272</td> 
                     <td>100%</td>
                 </tr>
                 <tr>
                     <th>2</th>
-                    <td><b>Zen</b></td>
-                    <td>0.188</td> 
-                    <td>102%</td> 
-                    <td>0.92282</td> 
-                    <td>36%</td>
+                    <td><b>Symfony</b></td>
+                    <td>0.211</td> 
+                    <td>104%</td> 
+                    <td>2.86004</td> 
+                    <td>307%</td>
                 </tr>
                 <tr>
                     <th>3</th>
                     <td><b>PHPixieDi</b></td>
-                    <td>0.601</td> 
-                    <td>327%</td> 
-                    <td>0.927</td> 
-                    <td>36%</td>
+                    <td>0.534</td> 
+                    <td>264%</td> 
+                    <td>0.93549</td> 
+                    <td>100%</td>
                 </tr>
                 <tr>
                     <th>4</th>
                     <td><b>ZendServiceManager</b></td>
-                    <td>0.650</td> 
-                    <td>353%</td> 
-                    <td>1.1183</td> 
-                    <td>44%</td>
+                    <td>0.629</td> 
+                    <td>311%</td> 
+                    <td>1.25507</td> 
+                    <td>135%</td>
                 </tr>
                 <tr>
                     <th>5</th>
                     <td><b>Pimple</b></td>
-                    <td>0.960</td> 
-                    <td>522%</td> 
-                    <td>1.07625</td> 
-                    <td>42%</td>
+                    <td>0.873</td> 
+                    <td>432%</td> 
+                    <td>1.08413</td> 
+                    <td>116%</td>
                 </tr>
                 <tr>
                     <th>6</th>
                     <td><b>Aura</b></td>
-                    <td>1.228</td> 
-                    <td>667%</td> 
-                    <td>0.92282</td> 
-                    <td>36%</td>
+                    <td>1.260</td> 
+                    <td>624%</td> 
+                    <td>0.93272</td> 
+                    <td>100%</td>
                 </tr>
                 <tr>
                     <th>7</th>
                     <td><b>Dice</b></td>
-                    <td>1.578</td> 
-                    <td>858%</td> 
-                    <td>1.01425</td> 
-                    <td>39%</td>
+                    <td>1.590</td> 
+                    <td>787%</td> 
+                    <td>1.01987</td> 
+                    <td>109%</td>
                 </tr>
                 <tr>
                     <th>8</th>
                     <td><b>Laravel</b></td>
-                    <td>2.935</td> 
-                    <td>1595%</td> 
-                    <td>0.92282</td> 
-                    <td>36%</td>
+                    <td>3.234</td> 
+                    <td>1601%</td> 
+                    <td>0.93272</td> 
+                    <td>100%</td>
                 </tr>
                 <tr>
                     <th>9</th>
                     <td><b>Auryn</b></td>
-                    <td>3.635</td> 
-                    <td>1976%</td> 
-                    <td>1.56615</td> 
-                    <td>61%</td>
+                    <td>3.373</td> 
+                    <td>1670%</td> 
+                    <td>1.23232</td> 
+                    <td>132%</td>
                 </tr>
                 <tr>
                     <th>10</th>
                     <td><b>PhpDi</b></td>
-                    <td>3.997</td> 
-                    <td>2172%</td> 
-                    <td>1.08775</td> 
-                    <td>42%</td>
+                    <td>3.970</td> 
+                    <td>1965%</td> 
+                    <td>1.05815</td> 
+                    <td>113%</td>
                 </tr>
                 <tr>
                     <th>11</th>
                     <td><b>Disco</b></td>
-                    <td>6.224</td> 
-                    <td>3383%</td> 
-                    <td>2.96001</td> 
-                    <td>115%</td>
+                    <td>6.156</td> 
+                    <td>3048%</td> 
+                    <td>2.24686</td> 
+                    <td>241%</td>
                 </tr>
             </tbody>
         </table>
@@ -362,90 +362,90 @@
             <tbody>                <tr>
                     <th>1</th>
                     <td><b>Symfony</b></td>
-                    <td>0.187</td> 
+                    <td>0.185</td> 
                     <td>100%</td> 
-                    <td>2.56815</td> 
+                    <td>2.86004</td> 
                     <td>100%</td>
                 </tr>
                 <tr>
                     <th>2</th>
                     <td><b>Zen</b></td>
-                    <td>0.224</td> 
-                    <td>120%</td> 
-                    <td>0.92282</td> 
-                    <td>36%</td>
+                    <td>0.218</td> 
+                    <td>118%</td> 
+                    <td>0.93272</td> 
+                    <td>33%</td>
                 </tr>
                 <tr>
                     <th>3</th>
                     <td><b>Disco</b></td>
-                    <td>0.372</td> 
-                    <td>199%</td> 
-                    <td>2.96001</td> 
-                    <td>115%</td>
+                    <td>0.381</td> 
+                    <td>206%</td> 
+                    <td>2.24686</td> 
+                    <td>79%</td>
                 </tr>
                 <tr>
                     <th>4</th>
                     <td><b>PHPixieDi</b></td>
-                    <td>0.504</td> 
-                    <td>270%</td> 
-                    <td>0.927</td> 
-                    <td>36%</td>
+                    <td>0.488</td> 
+                    <td>264%</td> 
+                    <td>0.93549</td> 
+                    <td>33%</td>
                 </tr>
                 <tr>
                     <th>5</th>
                     <td><b>ZendServiceManager</b></td>
-                    <td>0.632</td> 
-                    <td>338%</td> 
-                    <td>1.1183</td> 
+                    <td>0.609</td> 
+                    <td>329%</td> 
+                    <td>1.25507</td> 
                     <td>44%</td>
                 </tr>
                 <tr>
                     <th>6</th>
                     <td><b>Dice</b></td>
-                    <td>0.640</td> 
-                    <td>342%</td> 
-                    <td>1.01425</td> 
-                    <td>39%</td>
+                    <td>0.713</td> 
+                    <td>385%</td> 
+                    <td>1.01987</td> 
+                    <td>36%</td>
                 </tr>
                 <tr>
                     <th>7</th>
                     <td><b>Pimple</b></td>
-                    <td>0.852</td> 
-                    <td>456%</td> 
-                    <td>1.07625</td> 
-                    <td>42%</td>
+                    <td>0.824</td> 
+                    <td>445%</td> 
+                    <td>1.08413</td> 
+                    <td>38%</td>
                 </tr>
                 <tr>
                     <th>8</th>
                     <td><b>Aura</b></td>
-                    <td>1.222</td> 
-                    <td>653%</td> 
-                    <td>0.92282</td> 
-                    <td>36%</td>
+                    <td>1.257</td> 
+                    <td>679%</td> 
+                    <td>0.93272</td> 
+                    <td>33%</td>
                 </tr>
                 <tr>
                     <th>9</th>
-                    <td><b>Laravel</b></td>
-                    <td>2.892</td> 
-                    <td>1547%</td> 
-                    <td>0.92282</td> 
-                    <td>36%</td>
+                    <td><b>Auryn</b></td>
+                    <td>2.949</td> 
+                    <td>1594%</td> 
+                    <td>1.23232</td> 
+                    <td>43%</td>
                 </tr>
                 <tr>
                     <th>10</th>
-                    <td><b>Auryn</b></td>
-                    <td>3.146</td> 
-                    <td>1682%</td> 
-                    <td>1.56615</td> 
-                    <td>61%</td>
+                    <td><b>Laravel</b></td>
+                    <td>2.987</td> 
+                    <td>1615%</td> 
+                    <td>0.93272</td> 
+                    <td>33%</td>
                 </tr>
                 <tr>
                     <th>11</th>
                     <td><b>PhpDi</b></td>
-                    <td>4.371</td> 
-                    <td>2337%</td> 
-                    <td>1.08775</td> 
-                    <td>42%</td>
+                    <td>3.930</td> 
+                    <td>2124%</td> 
+                    <td>1.05815</td> 
+                    <td>37%</td>
                 </tr>
             </tbody>
         </table>
@@ -466,90 +466,90 @@
             <tbody>                <tr>
                     <th>1</th>
                     <td><b>Symfony</b></td>
-                    <td>1.732</td> 
+                    <td>1.408</td> 
                     <td>100%</td> 
-                    <td>2.56815</td> 
+                    <td>2.86004</td> 
                     <td>100%</td>
                 </tr>
                 <tr>
                     <th>2</th>
                     <td><b>Zen</b></td>
-                    <td>1.772</td> 
-                    <td>102%</td> 
-                    <td>0.92282</td> 
-                    <td>36%</td>
+                    <td>1.786</td> 
+                    <td>127%</td> 
+                    <td>0.93272</td> 
+                    <td>33%</td>
                 </tr>
                 <tr>
                     <th>3</th>
                     <td><b>PHPixieDi</b></td>
-                    <td>4.672</td> 
-                    <td>270%</td> 
-                    <td>0.927</td> 
-                    <td>36%</td>
+                    <td>4.751</td> 
+                    <td>337%</td> 
+                    <td>0.93549</td> 
+                    <td>33%</td>
                 </tr>
                 <tr>
                     <th>4</th>
                     <td><b>ZendServiceManager</b></td>
-                    <td>7.018</td> 
-                    <td>405%</td> 
-                    <td>1.1183</td> 
+                    <td>6.160</td> 
+                    <td>438%</td> 
+                    <td>1.25507</td> 
                     <td>44%</td>
                 </tr>
                 <tr>
                     <th>5</th>
                     <td><b>Dice</b></td>
-                    <td>7.437</td> 
-                    <td>429%</td> 
-                    <td>1.01425</td> 
-                    <td>39%</td>
+                    <td>7.630</td> 
+                    <td>542%</td> 
+                    <td>1.01987</td> 
+                    <td>36%</td>
                 </tr>
                 <tr>
                     <th>6</th>
                     <td><b>Pimple</b></td>
-                    <td>7.890</td> 
-                    <td>456%</td> 
-                    <td>1.07625</td> 
-                    <td>42%</td>
+                    <td>7.838</td> 
+                    <td>557%</td> 
+                    <td>1.08413</td> 
+                    <td>38%</td>
                 </tr>
                 <tr>
                     <th>7</th>
                     <td><b>Disco</b></td>
-                    <td>11.056</td> 
-                    <td>638%</td> 
-                    <td>2.96001</td> 
-                    <td>115%</td>
+                    <td>10.212</td> 
+                    <td>725%</td> 
+                    <td>2.24686</td> 
+                    <td>79%</td>
                 </tr>
                 <tr>
                     <th>8</th>
                     <td><b>Aura</b></td>
-                    <td>15.050</td> 
-                    <td>869%</td> 
-                    <td>0.92282</td> 
-                    <td>36%</td>
+                    <td>11.627</td> 
+                    <td>826%</td> 
+                    <td>0.93272</td> 
+                    <td>33%</td>
                 </tr>
                 <tr>
                     <th>9</th>
-                    <td><b>Laravel</b></td>
-                    <td>29.216</td> 
-                    <td>1687%</td> 
-                    <td>0.92282</td> 
-                    <td>36%</td>
+                    <td><b>Auryn</b></td>
+                    <td>30.832</td> 
+                    <td>2190%</td> 
+                    <td>1.23232</td> 
+                    <td>43%</td>
                 </tr>
                 <tr>
                     <th>10</th>
-                    <td><b>Auryn</b></td>
-                    <td>34.020</td> 
-                    <td>1964%</td> 
-                    <td>1.56615</td> 
-                    <td>61%</td>
+                    <td><b>Laravel</b></td>
+                    <td>30.951</td> 
+                    <td>2198%</td> 
+                    <td>0.93272</td> 
+                    <td>33%</td>
                 </tr>
                 <tr>
                     <th>11</th>
                     <td><b>PhpDi</b></td>
-                    <td>38.798</td> 
-                    <td>2240%</td> 
-                    <td>1.08775</td> 
-                    <td>42%</td>
+                    <td>45.629</td> 
+                    <td>3241%</td> 
+                    <td>1.05815</td> 
+                    <td>37%</td>
                 </tr>
             </tbody>
         </table>
@@ -570,91 +570,91 @@
             </thead>
             <tbody>                <tr>
                     <th>1</th>
-                    <td><b>Symfony</b></td>
-                    <td>0.139</td> 
+                    <td><b>Zen</b></td>
+                    <td>0.220</td> 
                     <td>100%</td> 
-                    <td>2.56815</td> 
+                    <td>1.03018</td> 
                     <td>100%</td>
                 </tr>
                 <tr>
                     <th>2</th>
-                    <td><b>Zen</b></td>
-                    <td>0.230</td> 
-                    <td>165%</td> 
-                    <td>1.00707</td> 
-                    <td>39%</td>
+                    <td><b>Symfony</b></td>
+                    <td>0.242</td> 
+                    <td>110%</td> 
+                    <td>2.86005</td> 
+                    <td>278%</td>
                 </tr>
                 <tr>
                     <th>3</th>
                     <td><b>PHPixieDi</b></td>
-                    <td>0.537</td> 
-                    <td>386%</td> 
-                    <td>1.11382</td> 
-                    <td>43%</td>
+                    <td>0.524</td> 
+                    <td>238%</td> 
+                    <td>1.18182</td> 
+                    <td>115%</td>
                 </tr>
                 <tr>
                     <th>4</th>
                     <td><b>ZendServiceManager</b></td>
-                    <td>0.735</td> 
-                    <td>529%</td> 
-                    <td>1.3011</td> 
-                    <td>51%</td>
+                    <td>0.666</td> 
+                    <td>303%</td> 
+                    <td>1.34052</td> 
+                    <td>130%</td>
                 </tr>
                 <tr>
                     <th>5</th>
                     <td><b>Pimple</b></td>
-                    <td>0.945</td> 
-                    <td>680%</td> 
-                    <td>1.20486</td> 
-                    <td>47%</td>
+                    <td>0.930</td> 
+                    <td>423%</td> 
+                    <td>1.20527</td> 
+                    <td>117%</td>
                 </tr>
                 <tr>
                     <th>6</th>
                     <td><b>Aura</b></td>
-                    <td>1.386</td> 
-                    <td>997%</td> 
-                    <td>1.20403</td> 
-                    <td>47%</td>
+                    <td>1.278</td> 
+                    <td>581%</td> 
+                    <td>1.18037</td> 
+                    <td>115%</td>
                 </tr>
                 <tr>
                     <th>7</th>
                     <td><b>Dice</b></td>
-                    <td>1.749</td> 
-                    <td>1258%</td> 
-                    <td>1.22676</td> 
-                    <td>48%</td>
+                    <td>1.808</td> 
+                    <td>822%</td> 
+                    <td>1.23238</td> 
+                    <td>120%</td>
                 </tr>
                 <tr>
                     <th>8</th>
                     <td><b>Laravel</b></td>
-                    <td>3.010</td> 
-                    <td>2165%</td> 
-                    <td>1.07857</td> 
-                    <td>42%</td>
+                    <td>3.037</td> 
+                    <td>1380%</td> 
+                    <td>1.08907</td> 
+                    <td>106%</td>
                 </tr>
                 <tr>
                     <th>9</th>
                     <td><b>Auryn</b></td>
-                    <td>3.903</td> 
-                    <td>2808%</td> 
-                    <td>1.56615</td> 
-                    <td>61%</td>
+                    <td>3.578</td> 
+                    <td>1626%</td> 
+                    <td>1.23232</td> 
+                    <td>120%</td>
                 </tr>
                 <tr>
                     <th>10</th>
                     <td><b>PhpDi</b></td>
-                    <td>4.665</td> 
-                    <td>3356%</td> 
-                    <td>1.75174</td> 
-                    <td>68%</td>
+                    <td>4.166</td> 
+                    <td>1894%</td> 
+                    <td>1.40384</td> 
+                    <td>136%</td>
                 </tr>
                 <tr>
                     <th>11</th>
                     <td><b>Disco</b></td>
-                    <td>6.557</td> 
-                    <td>4717%</td> 
-                    <td>2.96001</td> 
-                    <td>115%</td>
+                    <td>6.267</td> 
+                    <td>2849%</td> 
+                    <td>2.24686</td> 
+                    <td>218%</td>
                 </tr>
             </tbody>
         </table>
@@ -675,90 +675,90 @@
             <tbody>                <tr>
                     <th>1</th>
                     <td><b>Symfony</b></td>
-                    <td>0.157</td> 
+                    <td>0.142</td> 
                     <td>100%</td> 
-                    <td>2.56815</td> 
+                    <td>2.86005</td> 
                     <td>100%</td>
                 </tr>
                 <tr>
                     <th>2</th>
                     <td><b>Zen</b></td>
-                    <td>0.215</td> 
-                    <td>137%</td> 
-                    <td>1.00707</td> 
-                    <td>39%</td>
+                    <td>0.200</td> 
+                    <td>141%</td> 
+                    <td>1.03018</td> 
+                    <td>36%</td>
                 </tr>
                 <tr>
                     <th>3</th>
-                    <td><b>Disco</b></td>
-                    <td>0.376</td> 
-                    <td>239%</td> 
-                    <td>2.96001</td> 
-                    <td>115%</td>
+                    <td><b>PHPixieDi</b></td>
+                    <td>0.484</td> 
+                    <td>341%</td> 
+                    <td>1.18182</td> 
+                    <td>41%</td>
                 </tr>
                 <tr>
                     <th>4</th>
-                    <td><b>PHPixieDi</b></td>
-                    <td>0.515</td> 
-                    <td>328%</td> 
-                    <td>1.11382</td> 
-                    <td>43%</td>
+                    <td><b>Disco</b></td>
+                    <td>0.500</td> 
+                    <td>352%</td> 
+                    <td>2.24686</td> 
+                    <td>79%</td>
                 </tr>
                 <tr>
                     <th>5</th>
                     <td><b>ZendServiceManager</b></td>
-                    <td>0.658</td> 
-                    <td>419%</td> 
-                    <td>1.3011</td> 
-                    <td>51%</td>
+                    <td>0.651</td> 
+                    <td>458%</td> 
+                    <td>1.34052</td> 
+                    <td>47%</td>
                 </tr>
                 <tr>
                     <th>6</th>
                     <td><b>Dice</b></td>
-                    <td>0.755</td> 
-                    <td>481%</td> 
-                    <td>1.22676</td> 
-                    <td>48%</td>
+                    <td>0.735</td> 
+                    <td>518%</td> 
+                    <td>1.23238</td> 
+                    <td>43%</td>
                 </tr>
                 <tr>
                     <th>7</th>
                     <td><b>Pimple</b></td>
-                    <td>0.881</td> 
-                    <td>561%</td> 
-                    <td>1.20486</td> 
-                    <td>47%</td>
+                    <td>0.879</td> 
+                    <td>619%</td> 
+                    <td>1.20527</td> 
+                    <td>42%</td>
                 </tr>
                 <tr>
                     <th>8</th>
                     <td><b>Aura</b></td>
-                    <td>1.364</td> 
-                    <td>869%</td> 
-                    <td>1.20403</td> 
-                    <td>47%</td>
+                    <td>1.278</td> 
+                    <td>900%</td> 
+                    <td>1.18037</td> 
+                    <td>41%</td>
                 </tr>
                 <tr>
                     <th>9</th>
                     <td><b>Laravel</b></td>
-                    <td>2.969</td> 
-                    <td>1891%</td> 
-                    <td>1.07857</td> 
-                    <td>42%</td>
+                    <td>3.502</td> 
+                    <td>2466%</td> 
+                    <td>1.08907</td> 
+                    <td>38%</td>
                 </tr>
                 <tr>
                     <th>10</th>
                     <td><b>Auryn</b></td>
-                    <td>3.218</td> 
-                    <td>2050%</td> 
-                    <td>1.56615</td> 
-                    <td>61%</td>
+                    <td>3.524</td> 
+                    <td>2482%</td> 
+                    <td>1.23232</td> 
+                    <td>43%</td>
                 </tr>
                 <tr>
                     <th>11</th>
                     <td><b>PhpDi</b></td>
-                    <td>4.451</td> 
-                    <td>2835%</td> 
-                    <td>1.75174</td> 
-                    <td>68%</td>
+                    <td>5.383</td> 
+                    <td>3791%</td> 
+                    <td>1.40384</td> 
+                    <td>49%</td>
                 </tr>
             </tbody>
         </table>
@@ -779,90 +779,90 @@
             <tbody>                <tr>
                     <th>1</th>
                     <td><b>Symfony</b></td>
-                    <td>1.199</td> 
+                    <td>1.163</td> 
                     <td>100%</td> 
-                    <td>2.56815</td> 
+                    <td>2.86005</td> 
                     <td>100%</td>
                 </tr>
                 <tr>
                     <th>2</th>
                     <td><b>Zen</b></td>
-                    <td>1.824</td> 
-                    <td>152%</td> 
-                    <td>1.00707</td> 
-                    <td>39%</td>
+                    <td>1.972</td> 
+                    <td>170%</td> 
+                    <td>1.03018</td> 
+                    <td>36%</td>
                 </tr>
                 <tr>
                     <th>3</th>
-                    <td><b>PHPixieDi</b></td>
-                    <td>4.886</td> 
-                    <td>408%</td> 
-                    <td>1.11382</td> 
-                    <td>43%</td>
+                    <td><b>ZendServiceManager</b></td>
+                    <td>6.363</td> 
+                    <td>547%</td> 
+                    <td>1.34052</td> 
+                    <td>47%</td>
                 </tr>
                 <tr>
                     <th>4</th>
-                    <td><b>ZendServiceManager</b></td>
-                    <td>6.612</td> 
-                    <td>551%</td> 
-                    <td>1.3011</td> 
-                    <td>51%</td>
+                    <td><b>PHPixieDi</b></td>
+                    <td>6.572</td> 
+                    <td>565%</td> 
+                    <td>1.18182</td> 
+                    <td>41%</td>
                 </tr>
                 <tr>
                     <th>5</th>
-                    <td><b>Dice</b></td>
-                    <td>7.905</td> 
-                    <td>659%</td> 
-                    <td>1.22676</td> 
-                    <td>48%</td>
+                    <td><b>Pimple</b></td>
+                    <td>8.527</td> 
+                    <td>733%</td> 
+                    <td>1.20527</td> 
+                    <td>42%</td>
                 </tr>
                 <tr>
                     <th>6</th>
-                    <td><b>Pimple</b></td>
-                    <td>8.784</td> 
-                    <td>733%</td> 
-                    <td>1.20486</td> 
-                    <td>47%</td>
+                    <td><b>Dice</b></td>
+                    <td>8.916</td> 
+                    <td>767%</td> 
+                    <td>1.23238</td> 
+                    <td>43%</td>
                 </tr>
                 <tr>
                     <th>7</th>
                     <td><b>Disco</b></td>
-                    <td>10.635</td> 
-                    <td>887%</td> 
-                    <td>2.96001</td> 
-                    <td>115%</td>
+                    <td>13.022</td> 
+                    <td>1120%</td> 
+                    <td>2.24686</td> 
+                    <td>79%</td>
                 </tr>
                 <tr>
                     <th>8</th>
                     <td><b>Aura</b></td>
-                    <td>12.976</td> 
-                    <td>1082%</td> 
-                    <td>1.20403</td> 
-                    <td>47%</td>
+                    <td>16.291</td> 
+                    <td>1401%</td> 
+                    <td>1.18037</td> 
+                    <td>41%</td>
                 </tr>
                 <tr>
                     <th>9</th>
                     <td><b>Laravel</b></td>
-                    <td>30.084</td> 
-                    <td>2509%</td> 
-                    <td>1.07857</td> 
-                    <td>42%</td>
+                    <td>31.067</td> 
+                    <td>2671%</td> 
+                    <td>1.08907</td> 
+                    <td>38%</td>
                 </tr>
                 <tr>
                     <th>10</th>
-                    <td><b>Auryn</b></td>
-                    <td>33.691</td> 
-                    <td>2810%</td> 
-                    <td>1.56615</td> 
-                    <td>61%</td>
+                    <td><b>PhpDi</b></td>
+                    <td>46.893</td> 
+                    <td>4032%</td> 
+                    <td>1.40384</td> 
+                    <td>49%</td>
                 </tr>
                 <tr>
                     <th>11</th>
-                    <td><b>PhpDi</b></td>
-                    <td>45.595</td> 
-                    <td>3803%</td> 
-                    <td>1.75174</td> 
-                    <td>68%</td>
+                    <td><b>Auryn</b></td>
+                    <td>51.215</td> 
+                    <td>4404%</td> 
+                    <td>1.23232</td> 
+                    <td>43%</td>
                 </tr>
             </tbody>
         </table>
@@ -883,90 +883,90 @@
             <tbody>                <tr>
                     <th>1</th>
                     <td><b>Symfony</b></td>
-                    <td>11.552</td> 
+                    <td>12.076</td> 
                     <td>100%</td> 
-                    <td>2.56815</td> 
+                    <td>2.86005</td> 
                     <td>100%</td>
                 </tr>
                 <tr>
                     <th>2</th>
                     <td><b>Zen</b></td>
-                    <td>17.747</td> 
-                    <td>154%</td> 
-                    <td>1.00707</td> 
-                    <td>39%</td>
+                    <td>19.523</td> 
+                    <td>162%</td> 
+                    <td>1.03018</td> 
+                    <td>36%</td>
                 </tr>
                 <tr>
                     <th>3</th>
-                    <td><b>PHPixieDi</b></td>
-                    <td>45.705</td> 
-                    <td>396%</td> 
-                    <td>1.11382</td> 
-                    <td>43%</td>
+                    <td><b>Disco</b></td>
+                    <td>46.961</td> 
+                    <td>389%</td> 
+                    <td>2.24686</td> 
+                    <td>79%</td>
                 </tr>
                 <tr>
                     <th>4</th>
-                    <td><b>Disco</b></td>
-                    <td>47.575</td> 
-                    <td>412%</td> 
-                    <td>2.96001</td> 
-                    <td>115%</td>
+                    <td><b>PHPixieDi</b></td>
+                    <td>51.447</td> 
+                    <td>426%</td> 
+                    <td>1.18182</td> 
+                    <td>41%</td>
                 </tr>
                 <tr>
                     <th>5</th>
                     <td><b>ZendServiceManager</b></td>
-                    <td>69.167</td> 
-                    <td>599%</td> 
-                    <td>1.3011</td> 
-                    <td>51%</td>
+                    <td>67.784</td> 
+                    <td>561%</td> 
+                    <td>1.34052</td> 
+                    <td>47%</td>
                 </tr>
                 <tr>
                     <th>6</th>
                     <td><b>Dice</b></td>
-                    <td>75.769</td> 
-                    <td>656%</td> 
-                    <td>1.22676</td> 
-                    <td>48%</td>
+                    <td>79.840</td> 
+                    <td>661%</td> 
+                    <td>1.23238</td> 
+                    <td>43%</td>
                 </tr>
                 <tr>
                     <th>7</th>
                     <td><b>Pimple</b></td>
-                    <td>92.522</td> 
-                    <td>801%</td> 
-                    <td>1.20486</td> 
-                    <td>47%</td>
+                    <td>87.930</td> 
+                    <td>728%</td> 
+                    <td>1.20527</td> 
+                    <td>42%</td>
                 </tr>
                 <tr>
                     <th>8</th>
                     <td><b>Aura</b></td>
-                    <td>138.844</td> 
-                    <td>1202%</td> 
-                    <td>1.20403</td> 
-                    <td>47%</td>
+                    <td>135.715</td> 
+                    <td>1124%</td> 
+                    <td>1.18037</td> 
+                    <td>41%</td>
                 </tr>
                 <tr>
                     <th>9</th>
                     <td><b>Laravel</b></td>
-                    <td>341.327</td> 
-                    <td>2955%</td> 
-                    <td>1.07857</td> 
-                    <td>42%</td>
+                    <td>317.256</td> 
+                    <td>2627%</td> 
+                    <td>1.08907</td> 
+                    <td>38%</td>
                 </tr>
                 <tr>
                     <th>10</th>
                     <td><b>Auryn</b></td>
-                    <td>358.135</td> 
-                    <td>3100%</td> 
-                    <td>1.56615</td> 
-                    <td>61%</td>
+                    <td>324.167</td> 
+                    <td>2684%</td> 
+                    <td>1.23232</td> 
+                    <td>43%</td>
                 </tr>
                 <tr>
                     <th>11</th>
                     <td><b>PhpDi</b></td>
-                    <td>454.982</td> 
-                    <td>3939%</td> 
-                    <td>1.75174</td> 
-                    <td>68%</td>
+                    <td>435.478</td> 
+                    <td>3606%</td> 
+                    <td>1.40384</td> 
+                    <td>49%</td>
                 </tr>
             </tbody>
         </table>
@@ -988,90 +988,90 @@
             <tbody>                <tr>
                     <th>1</th>
                     <td><b>ZendServiceManager</b></td>
-                    <td>1.037</td> 
+                    <td>1.058</td> 
                     <td>100%</td> 
-                    <td>1.11948</td> 
+                    <td>1.25507</td> 
                     <td>100%</td>
                 </tr>
                 <tr>
                     <th>2</th>
                     <td><b>Aura</b></td>
-                    <td>1.091</td> 
-                    <td>105%</td> 
-                    <td>0.92282</td> 
-                    <td>82%</td>
+                    <td>1.098</td> 
+                    <td>104%</td> 
+                    <td>0.93272</td> 
+                    <td>74%</td>
                 </tr>
                 <tr>
                     <th>3</th>
-                    <td><b>PhpDi</b></td>
-                    <td>1.477</td> 
-                    <td>142%</td> 
-                    <td>1.01556</td> 
-                    <td>91%</td>
+                    <td><b>Zen</b></td>
+                    <td>1.373</td> 
+                    <td>130%</td> 
+                    <td>0.95399</td> 
+                    <td>76%</td>
                 </tr>
                 <tr>
                     <th>4</th>
                     <td><b>Pimple</b></td>
-                    <td>1.770</td> 
-                    <td>171%</td> 
-                    <td>1.07625</td> 
-                    <td>96%</td>
+                    <td>1.836</td> 
+                    <td>174%</td> 
+                    <td>1.08413</td> 
+                    <td>86%</td>
                 </tr>
                 <tr>
                     <th>5</th>
-                    <td><b>Zen</b></td>
-                    <td>1.863</td> 
-                    <td>180%</td> 
-                    <td>0.94602</td> 
-                    <td>85%</td>
+                    <td><b>PhpDi</b></td>
+                    <td>1.897</td> 
+                    <td>179%</td> 
+                    <td>0.97449</td> 
+                    <td>78%</td>
                 </tr>
                 <tr>
                     <th>6</th>
                     <td><b>Dice</b></td>
-                    <td>2.202</td> 
-                    <td>212%</td> 
-                    <td>1.01653</td> 
-                    <td>91%</td>
+                    <td>2.386</td> 
+                    <td>226%</td> 
+                    <td>1.02216</td> 
+                    <td>81%</td>
                 </tr>
                 <tr>
                     <th>7</th>
-                    <td><b>Laravel</b></td>
-                    <td>3.544</td> 
-                    <td>342%</td> 
-                    <td>0.92282</td> 
-                    <td>82%</td>
+                    <td><b>Symfony</b></td>
+                    <td>2.423</td> 
+                    <td>229%</td> 
+                    <td>0.97504</td> 
+                    <td>78%</td>
                 </tr>
                 <tr>
                     <th>8</th>
-                    <td><b>Symfony</b></td>
-                    <td>4.078</td> 
-                    <td>393%</td> 
-                    <td>0.92282</td> 
-                    <td>82%</td>
+                    <td><b>Laravel</b></td>
+                    <td>3.516</td> 
+                    <td>332%</td> 
+                    <td>0.93272</td> 
+                    <td>74%</td>
                 </tr>
                 <tr>
                     <th>9</th>
                     <td><b>Auryn</b></td>
-                    <td>4.899</td> 
-                    <td>472%</td> 
-                    <td>0.92282</td> 
-                    <td>82%</td>
+                    <td>5.220</td> 
+                    <td>493%</td> 
+                    <td>1.00655</td> 
+                    <td>80%</td>
                 </tr>
                 <tr>
                     <th>10</th>
                     <td><b>PHPixieDi</b></td>
-                    <td>5.075</td> 
-                    <td>489%</td> 
-                    <td>0.92283</td> 
-                    <td>82%</td>
+                    <td>5.482</td> 
+                    <td>518%</td> 
+                    <td>0.93273</td> 
+                    <td>74%</td>
                 </tr>
                 <tr>
                     <th>11</th>
                     <td><b>Disco</b></td>
-                    <td>11.083</td> 
-                    <td>1069%</td> 
-                    <td>3.18197</td> 
-                    <td>284%</td>
+                    <td>9.287</td> 
+                    <td>878%</td> 
+                    <td>2.47263</td> 
+                    <td>197%</td>
                 </tr>
             </tbody>
         </table>
@@ -1092,91 +1092,91 @@
             </thead>
             <tbody>                <tr>
                     <th>1</th>
-                    <td><b>ZendServiceManager</b></td>
-                    <td>1.034</td> 
+                    <td><b>Aura</b></td>
+                    <td>1.172</td> 
                     <td>100%</td> 
-                    <td>1.31429</td> 
+                    <td>1.21155</td> 
                     <td>100%</td>
                 </tr>
                 <tr>
                     <th>2</th>
-                    <td><b>Aura</b></td>
-                    <td>1.081</td> 
-                    <td>105%</td> 
-                    <td>1.23512</td> 
-                    <td>94%</td>
+                    <td><b>ZendServiceManager</b></td>
+                    <td>1.174</td> 
+                    <td>100%</td> 
+                    <td>1.34052</td> 
+                    <td>111%</td>
                 </tr>
                 <tr>
                     <th>3</th>
                     <td><b>Zen</b></td>
-                    <td>1.379</td> 
-                    <td>133%</td> 
-                    <td>1.0379</td> 
-                    <td>79%</td>
+                    <td>1.455</td> 
+                    <td>124%</td> 
+                    <td>1.07465</td> 
+                    <td>89%</td>
                 </tr>
                 <tr>
                     <th>4</th>
                     <td><b>PhpDi</b></td>
-                    <td>1.525</td> 
-                    <td>147%</td> 
-                    <td>1.67894</td> 
-                    <td>128%</td>
+                    <td>1.710</td> 
+                    <td>146%</td> 
+                    <td>1.39611</td> 
+                    <td>115%</td>
                 </tr>
                 <tr>
                     <th>5</th>
                     <td><b>Pimple</b></td>
-                    <td>1.762</td> 
-                    <td>170%</td> 
-                    <td>1.21505</td> 
-                    <td>92%</td>
+                    <td>1.957</td> 
+                    <td>167%</td> 
+                    <td>1.21546</td> 
+                    <td>100%</td>
                 </tr>
                 <tr>
                     <th>6</th>
-                    <td><b>Dice</b></td>
-                    <td>2.139</td> 
-                    <td>207%</td> 
-                    <td>1.25204</td> 
-                    <td>95%</td>
+                    <td><b>Symfony</b></td>
+                    <td>2.226</td> 
+                    <td>190%</td> 
+                    <td>1.10968</td> 
+                    <td>92%</td>
                 </tr>
                 <tr>
                     <th>7</th>
-                    <td><b>Laravel</b></td>
-                    <td>3.336</td> 
-                    <td>323%</td> 
-                    <td>1.07857</td> 
-                    <td>82%</td>
+                    <td><b>Dice</b></td>
+                    <td>2.241</td> 
+                    <td>191%</td> 
+                    <td>1.25766</td> 
+                    <td>104%</td>
                 </tr>
                 <tr>
                     <th>8</th>
-                    <td><b>Symfony</b></td>
-                    <td>4.329</td> 
-                    <td>419%</td> 
-                    <td>1.08089</td> 
-                    <td>82%</td>
+                    <td><b>Laravel</b></td>
+                    <td>3.356</td> 
+                    <td>286%</td> 
+                    <td>1.08907</td> 
+                    <td>90%</td>
                 </tr>
                 <tr>
                     <th>9</th>
-                    <td><b>Auryn</b></td>
-                    <td>4.949</td> 
-                    <td>479%</td> 
-                    <td>1.42967</td> 
-                    <td>109%</td>
+                    <td><b>PHPixieDi</b></td>
+                    <td>5.050</td> 
+                    <td>431%</td> 
+                    <td>1.16822</td> 
+                    <td>96%</td>
                 </tr>
                 <tr>
                     <th>10</th>
-                    <td><b>PHPixieDi</b></td>
-                    <td>5.091</td> 
-                    <td>492%</td> 
-                    <td>1.10098</td> 
-                    <td>84%</td>
+                    <td><b>Auryn</b></td>
+                    <td>5.189</td> 
+                    <td>443%</td> 
+                    <td>1.09605</td> 
+                    <td>90%</td>
                 </tr>
                 <tr>
                     <th>11</th>
                     <td><b>Disco</b></td>
-                    <td>9.819</td> 
-                    <td>950%</td> 
-                    <td>3.18198</td> 
-                    <td>242%</td>
+                    <td>9.348</td> 
+                    <td>798%</td> 
+                    <td>2.47264</td> 
+                    <td>204%</td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
Symfony expect lower cased service ids. It can work with service names containing mixed case but with a performance penalty (the container try to find the orignal service key and only if doesn't exist lower case it and try again).

(Work done with @nicolas-grekas).