### PR TITLE
More efficient rule loading

### DIFF
--- a/src/Container/Dice/AbstractDiceTest.php
+++ b/src/Container/Dice/AbstractDiceTest.php
@@ -16,9 +16,6 @@ abstract class AbstractDiceTest implements TestInterface
     protected function setContainerWithPrototypeServices(): void
     {
         $container = new Dice();
-        for ($i = 1; $i <= 100; $i++) {
-            $container->addRule('DiContainerBenchmarks\Fixture\Class' . $i, ["shared" => false]);
-        }
 
         $this->container = $container;
     }
@@ -26,9 +23,9 @@ abstract class AbstractDiceTest implements TestInterface
     protected function setContainerWithSingletonServices(): void
     {
         $container = new Dice();
-        for ($i = 1; $i <= 100; $i++) {
-            $container->addRule('DiContainerBenchmarks\Fixture\Class' . $i, ["shared" => true]);
-        }
+       
+        $container->addRule('*', ["shared" => true]);
+        
 
         $this->container = $container;
     }


### PR DESCRIPTION
Adding a hundred rules to dice will inevitably slow it down, Dice is intended as convention over configuration.