### PR TITLE
Update joomla/di to latest, change prototype tests to match other updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "bitexpert/disco": "^0.9.0",
         "doctrine/cache": "^1.6.1",
         "illuminate/container": "^v5.4.0",
-        "joomla/di": "^1.4",
+        "joomla/di": "^1.5.1",
         "jshannon63/cobalt": "^1.1",
         "level-2/dice": "dev-master",
         "opulence/ioc": "^1.0.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e0a0415e5a31bfbb31e4cca70764f48",
+    "content-hash": "c2c78a08e266b6582af01a03bf6a916a",
     "packages": [
         {
             "name": "aura/di",
@@ -745,16 +745,16 @@
         },
         {
             "name": "joomla/di",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/di.git",
-                "reference": "da21d37589706da13eca0bb075452c851821ea3b"
+                "reference": "33c66e4091e4433f33ddf4a0ac36604cf3b73c41"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/di/zipball/da21d37589706da13eca0bb075452c851821ea3b",
-                "reference": "da21d37589706da13eca0bb075452c851821ea3b",
+                "url": "https://api.github.com/repos/joomla-framework/di/zipball/33c66e4091e4433f33ddf4a0ac36604cf3b73c41",
+                "reference": "33c66e4091e4433f33ddf4a0ac36604cf3b73c41",
                 "shasum": ""
             },
             "require": {
@@ -765,8 +765,8 @@
                 "psr/container-implementation": "~1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35|^5.4.3|~6.0",
-                "squizlabs/php_codesniffer": "1.*"
+                "joomla/coding-standards": "~2.0@alpha",
+                "phpunit/phpunit": "^4.8.35|^5.4.3|~6.0"
             },
             "type": "joomla-package",
             "extra": {
@@ -793,7 +793,7 @@
                 "ioc",
                 "joomla"
             ],
-            "time": "2018-02-09T00:35:34+00:00"
+            "time": "2018-02-25T16:30:45+00:00"
         },
         {
             "name": "jshannon63/cobalt",

--- a/src/Container/Joomla/Test3.php
+++ b/src/Container/Joomla/Test3.php
@@ -14,6 +14,6 @@ class Test3 extends AbstractJoomlaTest
 
     public function run(): void
     {
-        $this->container->buildObject(Class10::class);
+        $this->container->get(Class10::class);
     }
 }

--- a/src/Container/Joomla/Test4.php
+++ b/src/Container/Joomla/Test4.php
@@ -14,6 +14,6 @@ class Test4 extends AbstractJoomlaTest
 
     public function run(): void
     {
-        $this->container->buildObject(Class100::class);
+        $this->container->get(Class100::class);
     }
 }


### PR DESCRIPTION
I just recently saw the updates @nicolas-grekas made in https://github.com/kocsismate/php-di-container-benchmarks/pull/21 to the Joomla tests, and after reviewing them, the method of retrieving objects from the container can be updated as well.

When I originally wrote the test cases, for the prototype tests I actually ended up configuring those in a way where the container would autowire all the services.  With the tests now correctly using a configured container with prototypes, the tests shouldn't use our container's method which handles autowiring but instead use the normal `Container::get()`.  This would also mildly influence the test result because before the tag I just created our `Container::buildObject()` method was always building a new instance and not checking for existence beforehand (so these tests were influenced by the time it took to build an object then run `Container::set()` and `Container::get()`.  So the test result should now more accurately reflect only resolving prototyped services and not any of the autowiring behavior.